### PR TITLE
Fix Missing Output Assignment to Flink in Flink-NATS Connector

### DIFF
--- a/src/examples/java/io/synadia/flink/examples/v0/SourceToSinkJsExample.java
+++ b/src/examples/java/io/synadia/flink/examples/v0/SourceToSinkJsExample.java
@@ -14,6 +14,7 @@ import io.synadia.flink.v0.sink.NatsSinkBuilder;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
@@ -60,7 +61,8 @@ public class SourceToSinkJsExample {
                 .connectionProperties(connectionProperties)
                 .consumerName(consumerName)
                 .maxFetchRecords(100)
-                .maxFetchTime(Duration.ofSeconds(5));
+                .maxFetchTime(Duration.ofSeconds(5))
+                .boundness(Boundedness.BOUNDED);
 
         NatsJetStreamSource<String> natsSource = builder.build();
 

--- a/src/examples/java/io/synadia/flink/examples/v0/SourceToSinkJsExample.java
+++ b/src/examples/java/io/synadia/flink/examples/v0/SourceToSinkJsExample.java
@@ -17,6 +17,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +58,9 @@ public class SourceToSinkJsExample {
                 .subjects(sourceSubject)
                 .payloadDeserializer(deserializer) // Deserialize messages from source
                 .connectionProperties(connectionProperties)
-                .consumerName(consumerName);
+                .consumerName(consumerName)
+                .maxFetchRecords(100)
+                .maxFetchTime(Duration.ofSeconds(5));
 
         NatsJetStreamSource<String> natsSource = builder.build();
 

--- a/src/main/java/io/synadia/flink/v0/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/v0/NatsJetStreamSource.java
@@ -37,7 +37,7 @@ public class NatsJetStreamSource<OutputT> extends NatsSource<OutputT> {
     @Override
     public Boundedness getBoundedness() {
         logger.debug("{} | Boundedness", id);
-        return null; // TODO this varies from NatsSource, understand why
+        return Boundedness.CONTINUOUS_UNBOUNDED; // TODO this varies from NatsSource, understand why
     }
 
     @Override

--- a/src/main/java/io/synadia/flink/v0/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/v0/NatsJetStreamSource.java
@@ -37,7 +37,7 @@ public class NatsJetStreamSource<OutputT> extends NatsSource<OutputT> {
     @Override
     public Boundedness getBoundedness() {
         logger.debug("{} | Boundedness", id);
-        return Boundedness.CONTINUOUS_UNBOUNDED; // TODO this varies from NatsSource, understand why
+        return sourceConfiguration.getBoundedness(); // TODO this varies from NatsSource, understand why
     }
 
     @Override

--- a/src/main/java/io/synadia/flink/v0/NatsJetStreamSourceBuilder.java
+++ b/src/main/java/io/synadia/flink/v0/NatsJetStreamSourceBuilder.java
@@ -6,6 +6,7 @@ package io.synadia.flink.v0;
 import io.synadia.flink.utils.Constants;
 import io.synadia.flink.utils.PropertiesUtils;
 import io.synadia.flink.v0.payload.PayloadDeserializer;
+import org.apache.flink.api.connector.source.Boundedness;
 
 import java.time.Duration;
 import java.util.Properties;
@@ -23,6 +24,7 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
     private Duration fetchTimeout;
     private int maxFetchRecords;
     private Duration autoAckInterval;
+    private Boundedness boundedness;
 
     public NatsJetStreamSourceBuilder() {
         super(SOURCE_PREFIX);
@@ -32,6 +34,7 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
         fetchTimeout = Duration.ofMillis(DEFAULT_FETCH_TIMEOUT_MS);
         maxFetchRecords = DEFAULT_MAX_FETCH_RECORDS;
         autoAckInterval = Duration.ofMillis(DEFAULT_AUTO_ACK_INTERVAL_MS);
+        boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
     }
 
     /**
@@ -113,6 +116,12 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
         return this;
     }
 
+    public NatsJetStreamSourceBuilder<OutputT> boundness(Boundedness boundedness){
+        this.boundedness = boundedness;
+        return this;
+    }
+
+
     /**
      * Build a NatsJetStreamSource.
      * @return the source
@@ -149,6 +158,6 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
                 fetchOneMessageTimeout,
                 fetchTimeout,
                 maxFetchRecords,
-                autoAckInterval));
+                autoAckInterval, boundedness));
     }
 }

--- a/src/main/java/io/synadia/flink/v0/NatsJetStreamSourceConfiguration.java
+++ b/src/main/java/io/synadia/flink/v0/NatsJetStreamSourceConfiguration.java
@@ -3,6 +3,7 @@
 
 package io.synadia.flink.v0;
 
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
 
@@ -20,6 +21,7 @@ public class NatsJetStreamSourceConfiguration implements Serializable {
     private final int maxFetchRecords;
     private final Duration autoAckInterval;
     private final Configuration configuration;
+    private final Boundedness boundedness;
 
     NatsJetStreamSourceConfiguration(String consumerName,
                                             int messageQueueCapacity,
@@ -27,7 +29,8 @@ public class NatsJetStreamSourceConfiguration implements Serializable {
                                             Duration fetchOneMessageTimeout,
                                             Duration fetchTimeout,
                                             int maxFetchRecords,
-                                            Duration autoAckInterval) {
+                                            Duration autoAckInterval,
+                                            Boundedness boundedness) {
         this.consumerName = consumerName;
         this.messageQueueCapacity = messageQueueCapacity;
         this.enableAutoAcknowledgeMessage = enableAutoAcknowledgeMessage;
@@ -37,6 +40,7 @@ public class NatsJetStreamSourceConfiguration implements Serializable {
         this.autoAckInterval = autoAckInterval;
         configuration = new Configuration();
         configuration.setInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY.key(), messageQueueCapacity);
+        this.boundedness = boundedness;
     }
 
     public String getConsumerName() {
@@ -69,5 +73,9 @@ public class NatsJetStreamSourceConfiguration implements Serializable {
 
     public Configuration getConfiguration() {
         return configuration;
+    }
+
+    public Boundedness getBoundedness() {
+        return boundedness;
     }
 }

--- a/src/main/java/io/synadia/flink/v0/emitter/NatsRecordEmitter.java
+++ b/src/main/java/io/synadia/flink/v0/emitter/NatsRecordEmitter.java
@@ -5,17 +5,14 @@ import io.synadia.flink.v0.payload.PayloadDeserializer;
 import io.synadia.flink.v0.source.split.NatsSubjectSplitState;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
-import org.apache.flink.util.Collector;
 
 public class NatsRecordEmitter<OutputT>
         implements RecordEmitter<Message, OutputT, NatsSubjectSplitState> {
 
     private final PayloadDeserializer<OutputT> payloadDeserializer;
-    private final SourceOutputWrapper<OutputT> sourceOutputWrapper;
 
     public NatsRecordEmitter(PayloadDeserializer<OutputT> payloadDeserializer) {
         this.payloadDeserializer = payloadDeserializer;
-        this.sourceOutputWrapper = new SourceOutputWrapper<>();
     }
 
     @Override
@@ -23,43 +20,9 @@ public class NatsRecordEmitter<OutputT>
                            SourceOutput<OutputT> output,
                            NatsSubjectSplitState splitState)
             throws Exception {
-        sourceOutputWrapper.setSourceOutput(output);
-        sourceOutputWrapper.setTimestamp(element);
-
         // Deserialize the message and since it to output.
-        payloadDeserializer.getObject(splitState.getSplit().getSubject(), element.getData(), null);
+        output.collect(payloadDeserializer.getObject(splitState.getSplit().getSubject(), element.getData(), element.getHeaders()));
         splitState.getSplit().getCurrentMessages().add(element);
-    }
-
-    private static class SourceOutputWrapper<OutputT> implements Collector<OutputT> {
-
-        private SourceOutput<OutputT> sourceOutput;
-        private long timestamp;
-
-        @Override
-        public void collect(OutputT record) {
-            if (timestamp > 0) {
-                sourceOutput.collect(record, timestamp);
-            } else {
-                sourceOutput.collect(record);
-            }
-        }
-
-        @Override
-        public void close() {
-            // Nothing to do here.
-        }
-
-        private void setSourceOutput(SourceOutput<OutputT> sourceOutput) {
-            this.sourceOutput = sourceOutput;
-        }
-
-        /**
-         * Set the event timestamp.
-         */
-        private void setTimestamp(Message message) {
-            this.timestamp = message.metaData().timestamp().toInstant().toEpochMilli();
-        }
     }
 }
 

--- a/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
@@ -62,8 +62,7 @@ public class NatsSubjectSplitReader
             }
         }
         catch(Exception e) {
-            LOG.error(e.getMessage(), e);
-            builder.addFinishedSplit(splitId); //Finish reading message from split if consumer is deleted for any reason.
+            throw new IOException(e); //Finish reading message from split if consumer is deleted for any reason.
         }
         LOG.debug("{} | {} | Finished polling message {}", id, splitId, 1);
 

--- a/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
@@ -57,13 +57,14 @@ public class NatsSubjectSplitReader
 
         String splitId = registeredSplit.splitId();
         List<Message> messages = jetStreamSubscription.fetch(sourceConfiguration.getMaxFetchRecords(), sourceConfiguration.getFetchTimeout());
+        messages.forEach((msg)-> {
+            builder.add(splitId,msg);
+        });
         //Stop consuming if running in batch mode and configured size of messages are fetched
         if (sourceConfiguration.getBoundedness() == Boundedness.BOUNDED && messages.size() <= sourceConfiguration.getMaxFetchRecords()){
             builder.addFinishedSplit(splitId);
         }
-        messages.forEach((msg)-> {
-            builder.add(splitId,msg);
-        });
+
         LOG.debug("{} | {} | Finished polling message {}", id, splitId, 1);
 
         return builder.build();


### PR DESCRIPTION
- Fix Nats Consumer Output Assignment Issue in Flink Integration, it fixes [https://github.com/synadia-io/flink-connector-nats/issues/14].
Statement was missing which would provide the nats Consumer message to flink for further processing
- Fix Nats Connection Closed Error During Message Acknowledgment.
Existing implementation was throwing error while acknowledgding a message, to solve this we are publishing a message to ReplyTo subject and "+ACK" string. Open for suggestion if we can fix it differently 
- Implement Stop/Continue Logic for Flink Job Based on Boundedness and Batch Message Count . 
Added boundess configuration in NatsJetstreamSourceBuilder based on which a job will either infinitely run (CONTIONUOUSLY_BOUNDESS) or stop (BOUNDED) when received message count are  <= configured max_fetch record. We can enhance this change further based on requirement.

I will improve the test cases going forward.