### PR TITLE
Fix Assertion Logic in Flink Source Tests and Validate End-to-End Data Flow with Improved Cleanup

### DIFF
--- a/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java
@@ -3,28 +3,34 @@
 
 package io.synadia.io.synadia.flink.v0;
 
-import io.nats.client.JetStream;
-import io.nats.client.JetStreamApiException;
-import io.nats.client.JetStreamManagement;
+import io.nats.client.*;
 import io.nats.client.api.*;
-import io.synadia.flink.v0.payload.PayloadDeserializer;
-import io.synadia.flink.v0.payload.StringPayloadDeserializer;
 import io.synadia.flink.v0.source.NatsJetStreamSource;
 import io.synadia.flink.v0.source.NatsJetStreamSourceBuilder;
+import io.synadia.flink.v0.payload.PayloadDeserializer;
+import io.synadia.flink.v0.payload.StringPayloadDeserializer;
+import io.synadia.flink.v0.payload.StringPayloadSerializer;
+import io.synadia.flink.v0.sink.NatsSink;
+import io.synadia.flink.v0.sink.NatsSinkBuilder;
 import io.synadia.io.synadia.flink.TestBase;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static io.nats.client.api.ConsumerConfiguration.INTEGER_UNSET;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JsSourceTests extends TestBase {
 
@@ -43,7 +49,9 @@ public class JsSourceTests extends TestBase {
 
     @Test
     public void testJsSourceBounded() throws Exception {
+        final List<Message> syncList = Collections.synchronizedList(new ArrayList<>());
         String sourceSubject = random("sub");
+        String sinkSubject = random("sink");
         String streamName = random("strm");
         String consumerName = random("con");
 
@@ -51,86 +59,138 @@ public class JsSourceTests extends TestBase {
             JetStreamManagement jsm = nc.jetStreamManagement();
             JetStream js = jsm.jetStream();
 
+            // Step 1: Create the source stream and publish messages
             createStream(jsm, streamName, sourceSubject);
             publish(js, sourceSubject, 10);
 
-            // --------------------------------------------------------------------------------
+            // Step 2: Create a JetStream consumer
+            createConsumer(jsm, streamName, sourceSubject, consumerName);
+
+            // Step 3: Configure the NATS JetStream Source
+            Properties connectionProperties = defaultConnectionProperties(url);
+            StringPayloadDeserializer deserializer = new StringPayloadDeserializer();
+            NatsJetStreamSourceBuilder<String> builder =
+                    new NatsJetStreamSourceBuilder<String>()
+                            .subjects(sourceSubject)
+                            .payloadDeserializer(deserializer)
+                            .connectionProperties(connectionProperties)
+                            .consumerName(consumerName)
+                            .maxFetchRecords(100)
+                            .maxFetchTime(Duration.ofSeconds(5))
+                            .boundness(Boundedness.BOUNDED);
+
+            // Step 4: Set up Flink Streaming Environment
+            NatsJetStreamSource<String> natsSource = builder.build();
+            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.getCheckpointConfig().setCheckpointInterval(10_000L);
+            DataStream<String> ds = env.fromSource(natsSource, WatermarkStrategy.noWatermarks(), "nats-source-input");
+
+            // Step 5: Listen to the sink subject and collect messages into syncList
+            Dispatcher dispatcher = nc.createDispatcher();
+            dispatcher.subscribe(sinkSubject, syncList::add); // Collect sink messages
+
+            // Step 6: Configure a NATS Sink to write processed data
+            NatsSink<String> sink = new NatsSinkBuilder<String>()
+                    .subjects(sinkSubject)
+                    .connectionProperties(connectionProperties)
+                    .payloadSerializer(new StringPayloadSerializer()) // Serialize messages for sink
+                    .build();
+            ds.map(String::toUpperCase).sinkTo(sink);
+
+            // Step 7: Set Flink restart strategy and execute the job asynchronously
+            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, Time.seconds(5)));
+            env.executeAsync("TestJsSourceBounded");
+
+            // Step 8: Wait for processing to complete
+            Thread.sleep(12_000);
+
+            // Step 9: Cleanup and validation
+            env.close();
+            assertEquals(10, syncList.size(), "All 10 messages should be received at the sink.");
+            jsm.deleteStream(streamName);
+            nc.close();
+        });
+    }
+
+
+    @Test
+    public void testJsSourceUnbounded() throws Exception {
+        final List<Message> syncList = Collections.synchronizedList(new ArrayList<>());
+        String sourceSubject = random("sub");
+        String sinkSubject = random("sink");
+        String streamName = random("strm");
+        String consumerName = random("con");
+
+        runInServer(true, (nc, url) -> {
+            JetStreamManagement jsm = nc.jetStreamManagement();
+            JetStream js = jsm.jetStream();
+
+            // Step 1: Create the source stream and publish messages
+            createStream(jsm, streamName, sourceSubject);
+            createConsumer(jsm, streamName, sourceSubject, consumerName);
+
+            // Step 2: NATS JetStream Source configuration
             Properties connectionProperties = defaultConnectionProperties(url);
             PayloadDeserializer<String> deserializer = new StringPayloadDeserializer();
-            NatsJetStreamSourceBuilder<String> builder =
-                new NatsJetStreamSourceBuilder<String>()
+            NatsJetStreamSourceBuilder<String> builder = new NatsJetStreamSourceBuilder<String>()
                     .subjects(sourceSubject)
                     .payloadDeserializer(deserializer)
                     .connectionProperties(connectionProperties)
                     .consumerName(consumerName)
-                    .maxFetchRecords(10)
+                    .maxFetchRecords(100)
                     .maxFetchTime(Duration.ofSeconds(5))
-                    .boundness(Boundedness.BOUNDED);
+                    .boundness(Boundedness.CONTINUOUS_UNBOUNDED);
 
-            NatsJetStreamSource<String> natsSource = builder.build();
-            StreamExecutionEnvironment env = getStreamExecutionEnvironment();
-            env.getCheckpointConfig().setCheckpointInterval(11_000L);
-            DataStream<String> ds = env.fromSource(natsSource, WatermarkStrategy.noWatermarks(), "nats-source-input");
-
-            ds.map(String::toUpperCase); //To Avoid Sink Dependency
-            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, Time.seconds(5)));
-            env.executeAsync("TestJsSourceBounded");
-
-            Thread.sleep(12_000);
-            env.close();
-            ConsumerInfo ci = jsm.getConsumerInfo(streamName, consumerName);
-            SequenceInfo sequenceInfo = ci.getDelivered();
-            assertTrue(sequenceInfo.getStreamSequence() >= 2);
-
-        });
-    }
-
-    @Test
-    public void testJsSourceUnbounded() throws Exception {
-        String sourceSubject = random("sub");
-        String streamName = random("strm");
-        String consumerName = random("con");
-
-        runInServer(true, (nc, url) -> {
-            JetStreamManagement jsm = nc.jetStreamManagement();
-            JetStream js = jsm.jetStream();
-            createStream(jsm, streamName, sourceSubject);
-
-            // --------------------------------------------------------------------------------
-            Properties connectionProperties = defaultConnectionProperties(url);
-            PayloadDeserializer<String> deserializer = new StringPayloadDeserializer();
-            NatsJetStreamSourceBuilder<String> builder = new NatsJetStreamSourceBuilder<String>()
-                .subjects(sourceSubject)
-                .payloadDeserializer(deserializer)
-                .connectionProperties(connectionProperties)
-                .consumerName(consumerName)
-                .maxFetchRecords(100)
-                .maxFetchTime(Duration.ofSeconds(5))
-                .boundness(Boundedness.CONTINUOUS_UNBOUNDED);
-
-            // Flink environment setup
+            // Step 3: Flink environment setup
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
+            // Source: Read from NATS
             DataStream<String> ds = env.fromSource(builder.build(), WatermarkStrategy.noWatermarks(), "nats-source-input");
-            ds.map(String::toUpperCase);
 
-            // Running Flink job in a separate thread
-            env.executeAsync("TestJsSourceUnbounded");
-            publish(js, sourceSubject, 5, 0);
+            // Step 4: Setup a Dispatcher to listen to the sink subject and capture messages
+            Dispatcher d = nc.createDispatcher();
+            d.subscribe(sinkSubject, syncList::add);
 
-            Thread.sleep(15_000L); // Increased sleep time to ensure messages are processed
+            // Sink: Write to a different subject
+            NatsSink<String> sink = new NatsSinkBuilder<String>()
+                    .subjects(sinkSubject)
+                    .connectionProperties(connectionProperties)
+                    .payloadSerializer(new StringPayloadSerializer()) // Serialize messages for sink
+                    .build();
+            ds.map(String::toUpperCase).sinkTo(sink);
+
+            // Step 5: Execute the Flink job asynchronously
+            JobClient jobClient = env.executeAsync("TestJsSourceUnbounded");
+
+            // Step 6: Publish messages to NATS JetStream
+            publish(js, sourceSubject, 5, 100);
+
+            // Wait for messages to process
+            Thread.sleep(10_000);
+
+            // Step 7: Verify received messages at sink
+            assertEquals(5, syncList.size(), "All 5 messages should be received at the sink.");
+
+            // Step 8: Cancel the Flink job gracefully
+            try {
+                jobClient.cancel().get();
+                System.out.println("Flink job canceled successfully.");
+            } catch (Exception e) {
+                e.printStackTrace();
+                fail("Failed to cancel Flink job: " + e.getMessage());
+            }
+
+            // Step 9: Cleanup
             env.close();
-            SequenceInfo sequenceInfo = nc.jetStream().getConsumerContext(streamName, consumerName).getConsumerInfo().getDelivered();
-            assertTrue(sequenceInfo.getStreamSequence() >= 5);
+            jsm.deleteStream(streamName);
         });
     }
 
-    private static ConsumerConfiguration createConsumer(JetStreamManagement jsm, String streamName, String sourceSubject, String consumerName, int maxBatch) throws IOException, JetStreamApiException {
+    private static ConsumerConfiguration createConsumer(JetStreamManagement jsm, String streamName, String sourceSubject, String consumerName) throws IOException, JetStreamApiException {
         ConsumerConfiguration cc = ConsumerConfiguration.builder()
             .durable(consumerName)
             .ackPolicy(AckPolicy.All)
             .filterSubject(sourceSubject)
-            .maxBatch(maxBatch)
             .build();
         jsm.addOrUpdateConsumer(streamName, cc);
         return cc;
@@ -140,7 +200,6 @@ public class JsSourceTests extends TestBase {
         StreamConfiguration streamConfig = StreamConfiguration.builder()
             .name(streamName)
             .subjects(sourceSubject)
-            .storageType(StorageType.Memory)
             .build();
         jsm.addStream(streamConfig);
     }


### PR DESCRIPTION
## Issue
The assertion logic in [`testSourceUnbounded()`](https://github.com/synadia-io/flink-connector-nats/blob/8111f74eeb24a3d2a127134d7e9bb095c983672b/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java#L45) & [`testSourceBounded()`](https://github.com/synadia-io/flink-connector-nats/blob/8111f74eeb24a3d2a127134d7e9bb095c983672b/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java#L89) was incorrect as we were checking if Source `StreamSequence >= 2`, which would always be true leading to a false positive.

A proper test should check if a Sink `subject` receives the processed messages from a `FlinkJob` satisfying our entire data flow (Source Subject -> Flink -> Sink Subject)

```
ConsumerInfo ci = jsm.getConsumerInfo(streamName, consumerName);
            SequenceInfo sequenceInfo = ci.getDelivered();
            assertTrue(sequenceInfo.getStreamSequence() >= 2);
```
## Fixes
### testJsSourceBounded()

- Validate the size of `syncList` which captures messages from `Sink` Subject instead of `Source`

```
assertEquals(10, syncList.size(), "All 10 messages should be received at the sink.");
```

- Add  [Flink Map](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/datastream/overview/#anatomy-of-a-flink-program) which applies a Transformation of each element in the Flink DataStream from `lowerCase` -> `upperCase` to simulate a Flink DataStream processing before writing to Sink Subject, further solidifying our test.

```
ds.map(String::toUpperCase).sinkTo(sink);
```

- Improve Nats Jetstream cleanup by deleting testStream and gracefully closing all connections.
```
jsm.deleteStream(streamName);
nc.close();
```

### testJsSourceUnbounded()

- Validate the size of `syncList` which captures messages from `Sink` Subject instead of `Source` as discussed previously.

-  Add  [Flink Map](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/datastream/overview/#anatomy-of-a-flink-program) which applies a Transformation as discussed previously.

-  Improve Nats Jetstream cleanup as discussed previously.

- Use Flink's [`JobClient`](https://nightlies.apache.org/flink/flink-docs-master/api/java/org/apache/flink/core/execution/JobClient.html) API which provides an interface to interact with `Flink Job` once its submitted to Flink cluster for execution, controlling the job's lifecycle. 
- - The `jobClient.cancel()` method returns a `CompletableFuture<Void>`, used to cancel the FlinkJob asynchronously. The `.get()` will block the calling thread until the cancellation process is finished and the job has been successfully canceled (or failed to cancel). 
- - This ensures in an `UNBOUNDED` streaming scenario, the FlinkJob is cancelled gracefully.

```
JobClient jobClient = env.executeAsync("TestJsSourceUnbounded");
jobClient.cancel().get();
```
- Wrap the previous implementation in a try/catch block to ensure proper handling of errors
```
try {
                jobClient.cancel().get();
                System.out.println("Flink job canceled successfully.");
            } catch (Exception e) {
                e.printStackTrace();
                fail("Failed to cancel Flink job: " + e.getMessage());
}
```
