### PR TITLE
Moved connections to the source reader from the split reader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
     testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.12.3'
+    testImplementation 'org.mockito:mockito-core:5.10.0'
 }
 
 sourceSets {

--- a/src/main/java/io/synadia/flink/v0/source/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/v0/source/NatsJetStreamSource.java
@@ -9,6 +9,7 @@ import io.synadia.flink.v0.source.reader.NatsJetStreamSourceReader;
 import io.synadia.flink.v0.source.reader.NatsSourceFetcherManager;
 import io.synadia.flink.v0.source.reader.NatsSubjectSplitReader;
 import io.synadia.flink.v0.source.split.NatsSubjectSplit;
+import io.synadia.flink.v0.utils.ConnectionContext;
 import io.synadia.flink.v0.utils.ConnectionFactory;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SourceReader;
@@ -16,8 +17,12 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.util.FlinkRuntimeException;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import static io.synadia.flink.v0.utils.MiscUtils.generateId;
@@ -25,12 +30,15 @@ import static io.synadia.flink.v0.utils.MiscUtils.generateId;
 public class NatsJetStreamSource<OutputT> extends NatsSource<OutputT> {
     protected final String id;
     private final NatsJetStreamSourceConfiguration sourceConfiguration;
+    private final Map<String, ConnectionContext> connections;
 
     NatsJetStreamSource(PayloadDeserializer<OutputT> payloadDeserializer, ConnectionFactory connectionFactory, List<String> subjects,
                         NatsJetStreamSourceConfiguration sourceConfiguration) {
         super(payloadDeserializer, connectionFactory, subjects, NatsJetStreamSource.class);
+
         id = generateId();
         this.sourceConfiguration = sourceConfiguration;
+        this.connections = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -42,22 +50,26 @@ public class NatsJetStreamSource<OutputT> extends NatsSource<OutputT> {
     @Override
     public SourceReader<OutputT, NatsSubjectSplit> createReader(SourceReaderContext readerContext) throws Exception {
         int queueCapacity = sourceConfiguration.getMessageQueueCapacity();
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<Message>> elementsQueue =
-            new FutureCompletingBlockingQueue<>(queueCapacity);
 
-        Supplier<SplitReader<Message, NatsSubjectSplit>> splitReaderSupplier =
-            () -> new NatsSubjectSplitReader(id, connectionFactory, sourceConfiguration);
+        FutureCompletingBlockingQueue<RecordsWithSplitIds<Message>> elementsQueue = new FutureCompletingBlockingQueue<>(queueCapacity);
+        NatsSourceFetcherManager fetcherManager = getNatsSourceFetcherManager(readerContext, elementsQueue);
 
-        NatsSourceFetcherManager fetcherManager =
-            new NatsSourceFetcherManager(
-                elementsQueue, splitReaderSupplier, readerContext.getConfiguration());
+        return new NatsJetStreamSourceReader<>(id, elementsQueue, fetcherManager, sourceConfiguration, connections, payloadDeserializer, readerContext);
+    }
 
-        return new NatsJetStreamSourceReader<>(
-            id,
-            elementsQueue,
-            fetcherManager,
-            sourceConfiguration, connectionFactory, payloadDeserializer,
-            readerContext);
+    private NatsSourceFetcherManager getNatsSourceFetcherManager(SourceReaderContext readerContext, FutureCompletingBlockingQueue<RecordsWithSplitIds<Message>> elementsQueue) throws FlinkRuntimeException {
+        Supplier<SplitReader<Message, NatsSubjectSplit>> splitReaderSupplier = () ->
+                new NatsSubjectSplitReader(id, connections, sourceConfiguration, (splitId) -> {
+                    try {
+
+                        this.connections.put(splitId, connectionFactory.connectContext());
+                        return this.connections.get(splitId);
+                    }
+                    catch (IOException e) {
+                        throw new IOException(e);
+                    }
+                });
+
+        return new NatsSourceFetcherManager(elementsQueue, splitReaderSupplier, readerContext.getConfiguration());
     }
 }
-

--- a/src/main/java/io/synadia/flink/v0/source/reader/Callback.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/Callback.java
@@ -1,0 +1,8 @@
+package io.synadia.flink.v0.source.reader;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface Callback<T, R> {
+    R newConnection(T input) throws IOException;
+}

--- a/src/test/java/io/synadia/io/synadia/flink/v0/NatsSubjectSplitReaderTest.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/NatsSubjectSplitReaderTest.java
@@ -1,0 +1,364 @@
+package io.synadia.io.synadia.flink.v0;
+
+import io.nats.client.*;
+import io.nats.client.api.StorageType;
+import io.nats.client.api.StreamConfiguration;
+import io.nats.client.api.StreamInfo;
+import io.synadia.flink.v0.source.NatsJetStreamSourceConfiguration;
+import io.synadia.flink.v0.source.reader.Callback;
+import io.synadia.flink.v0.source.reader.NatsSubjectSplitReader;
+import io.synadia.flink.v0.source.split.NatsSubjectSplit;
+import io.synadia.flink.v0.utils.ConnectionContext;
+import io.synadia.io.synadia.flink.v0.testutils.NatsSourceTestEnv;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.time.Duration;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class NatsSubjectSplitReaderTest extends NatsSourceTestEnv {
+    private static final String STREAM_NAME = "test-stream";
+    private static final String SOURCE_ID = "test-source";
+    private static final String SUBJECT_PREFIX = "test-subject";
+    private static final int MAX_FETCH_RECORDS = 100;
+
+    private Callback<String, ConnectionContext> callback;
+
+    private Map<String, ConnectionContext> connections;
+    private NatsJetStreamSourceConfiguration sourceConfig;
+    private NatsSubjectSplitReader reader;
+
+    @BeforeAll
+    static void createStream() throws Exception {
+        StreamConfiguration streamConfig = StreamConfiguration.builder()
+            .name(STREAM_NAME)
+            .subjects(SUBJECT_PREFIX + "-0")
+            .storageType(StorageType.Memory)
+            .build();
+
+        try {
+            // Check if stream exists
+            StreamInfo streamInfo = jsm.getStreamInfo(STREAM_NAME);
+            
+            // If exists but config differs, update it
+            if (!streamInfo.getConfiguration().equals(streamConfig)) {
+                jsm.updateStream(streamConfig);
+            }
+        } catch (JetStreamApiException e) {
+            if (e.getErrorCode() == 404) { // Stream not found
+                jsm.addStream(streamConfig);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Create mock callback
+        callback = mock(Callback.class);
+
+        try {
+            // Purge the stream but keep the stream configuration
+            jsm.purgeStream(STREAM_NAME);
+        } catch (JetStreamApiException e) {
+            if (e.getErrorCode() != 404) { // Ignore if stream doesn't exist
+                throw e;
+            }
+        }
+    }
+
+    @AfterAll
+    static void cleanUp() throws Exception {
+        try {
+            jsm.deleteStream(STREAM_NAME);
+        } catch (JetStreamApiException e) {
+            if (e.getErrorCode() != 404) { // Ignore if stream doesn't exist
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Sets up a test reader with specified parameters.
+     * 
+     * Setup process:
+     * 1. Configures mock behavior for connection callbacks
+     * 2. Creates source configuration with provided parameters
+     * 3. Initializes reader with test configuration
+     * 
+     * @param maxFetchRecords Maximum records to fetch per call
+     * @param boundedness Stream boundedness setting
+     * @param consumerName Name for the JetStream consumer
+     * @throws Exception if reader setup fails
+     */
+    private void setupReader(int maxFetchRecords, Boundedness boundedness, String consumerName) throws Exception {
+        // Setup mock
+        JetStreamOptions options = JetStreamOptions.builder().build();
+        ConnectionContext context = new ConnectionContext(natsConnection, options);
+        lenient().when(callback.newConnection(any())).thenReturn(context);
+
+        connections = new HashMap<>();
+        sourceConfig = createSourceConfig(
+            consumerName,
+            maxFetchRecords,
+            false,
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(1),
+            1000,
+            Duration.ofSeconds(10),
+            boundedness
+        );
+
+        reader = new NatsSubjectSplitReader(
+            SOURCE_ID,
+            connections,
+            sourceConfig,
+            callback
+        );
+    }
+
+    /**
+     * Tests basic split assignment and message fetching functionality.
+     * 
+     * Test scenario:
+     * 1. Sets up a reader with specified fetch limit and boundedness
+     * 2. Creates a stream with a single subject
+     * 3. Publishes test messages to the subject
+     * 4. Assigns split to the reader
+     * 5. Fetches and verifies messages
+     * 
+     * Expected behavior:
+     * - Reader should successfully connect to the stream
+     * - All published messages should be fetched
+     * - Message contents should match what was published
+     * 
+     * @throws Exception if any NATS operations fail
+     */
+    @Test
+    void testBasicSplitAssignmentAndFetch() throws Exception {
+        // Setup reader and test environment
+        setupReader(MAX_FETCH_RECORDS, Boundedness.CONTINUOUS_UNBOUNDED, "test-consumer");
+
+        // Create stream with subject
+        String subject = SUBJECT_PREFIX + "-0";
+        StreamConfiguration streamConfig = StreamConfiguration.builder()
+            .name(STREAM_NAME)
+            .subjects(subject)
+            .storageType(StorageType.Memory)
+            .build();
+
+        jsm.addStream(streamConfig);
+
+        // Publish test messages
+        publishTestMessages(subject, NUM_MESSAGES_PER_SUBJECT);
+
+        try {
+            // Create split for the subject
+            NatsSubjectSplit split = new NatsSubjectSplit(subject);
+
+            // Assign split directly
+            reader.handleSplitsChanges(
+                new SplitsAddition<>(Collections.singletonList(split))
+            );
+
+            // Wait a bit for messages to be available
+            Thread.sleep(1000);
+
+            // Fetch and verify records
+            RecordsWithSplitIds<Message> records = reader.fetch();
+            assertNotNull(records);
+
+            List<Message> messages = new ArrayList<>();
+
+            while ((records.nextSplit()) != null) {
+                Message message;
+                while ((message = records.nextRecordFromSplit()) != null) {
+                    messages.add(message);
+                }
+            }
+
+            // Verify messages
+            assertNotNull(messages);
+            assertEquals(NUM_MESSAGES_PER_SUBJECT, messages.size());
+
+            for (int i = 0; i < messages.size(); i++) {
+                Message msg = messages.get(i);
+                assertNotNull(msg);
+                assertEquals(String.valueOf(i), new String(msg.getData()));
+            }
+
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+
+    /**
+     * Tests the reader's auto-reconnection behavior when connection failure occurs.
+     *
+     * Test scenario:
+     * 1. Sets up a reader with mocked NATS components
+     * 2. Adds a split and verifies initial connection creation
+     * 3. Performs first fetch with working connection
+     * 4. Simulates connection failure by setting connection status to CLOSED
+     * 5. Performs second fetch which should trigger reconnection
+     *
+     * Expected behavior:
+     * - Initial connection and fetch should succeed
+     * - When connection is closed, fetch() should:
+     *   a. Detect the closed connection
+     *   b. Create a new connection via callback
+     *   c. Create new subscription with new connection
+     *   d. Successfully continue fetching messages
+     * - Verifies that auto-reconnection is properly implemented
+     *
+     * @throws Exception if any operations fail
+     */
+    @Test
+    void testConnectionReconnectionFailure() throws Exception {
+
+        // Mock all the components
+        Connection mockConnection = mock(Connection.class);
+        JetStream mockJs = mock(JetStream.class);
+        JetStreamManagement mockJsm = mock(JetStreamManagement.class);
+        JetStreamSubscription mockSubscription = mock(JetStreamSubscription.class);
+
+        // Setup initial connection state
+        when(mockConnection.getStatus()).thenReturn(Connection.Status.CONNECTED);
+        when(mockConnection.jetStream()).thenReturn(mockJs);
+        when(mockConnection.jetStreamManagement(any(JetStreamOptions.class))).thenReturn(mockJsm);
+        when(mockJsm.jetStream()).thenReturn(mockJs);
+        when(mockJs.subscribe(anyString(), any(PullSubscribeOptions.class))).thenReturn(mockSubscription);
+
+        // Create real context with mocked components
+        ConnectionContext context = new ConnectionContext(mockConnection, JetStreamOptions.builder().build());
+
+        // Setup reader
+        connections = new HashMap<>();
+        sourceConfig = createSourceConfig(
+                "test-consumer-reconnecting",
+                1,
+                false,
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(1),
+                1000,
+                Duration.ofSeconds(10),
+                Boundedness.CONTINUOUS_UNBOUNDED
+        );
+
+        // Setup callback to return our context
+        when(callback.newConnection(any())).thenReturn(context);
+
+        reader = new NatsSubjectSplitReader(
+                SOURCE_ID,
+                connections,
+                sourceConfig,
+                callback
+        );
+
+        try{
+            // Add a split
+            String subject = "test-subject";
+            NatsSubjectSplit split = new NatsSubjectSplit(subject);
+            reader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split)));
+
+            // First fetch - should succeed
+            when(mockSubscription.fetch(anyInt(), any())).thenReturn(Collections.singletonList(mock(Message.class)));
+            RecordsWithSplitIds<Message> records = reader.fetch();
+            assertNotNull(records);
+
+            // Simulate connection failure
+            when(mockConnection.getStatus()).thenReturn(Connection.Status.CLOSED);
+
+            // Setup new connection that will be returned after failure
+            Connection mockConnection2 = mock(Connection.class);
+            JetStream mockJs2 = mock(JetStream.class);
+            JetStreamManagement mockJsm2 = mock(JetStreamManagement.class);
+            JetStreamSubscription mockSubscription2 = mock(JetStreamSubscription.class);
+
+            when(mockConnection2.getStatus()).thenReturn(Connection.Status.CONNECTED);
+            when(mockConnection2.jetStream()).thenReturn(mockJs2);
+            when(mockConnection2.jetStreamManagement(any(JetStreamOptions.class))).thenReturn(mockJsm2);
+            when(mockJsm2.jetStream()).thenReturn(mockJs2);
+            when(mockJs2.subscribe(anyString(), any(PullSubscribeOptions.class))).thenReturn(mockSubscription2);
+
+            // Create second context with mocked components
+            ConnectionContext context2 = new ConnectionContext(mockConnection2, JetStreamOptions.builder().build());
+            when(callback.newConnection(any())).thenReturn(context2);
+
+            // Second fetch - should get new connection and succeed
+            when(mockSubscription2.fetch(anyInt(), any())).thenReturn(Collections.singletonList(mock(Message.class)));
+            records = reader.fetch();
+            assertNotNull(records);
+
+            // Verify that we got a new connection three times:
+            // 1. During handleSplitsChanges
+            // 2. During first fetch
+            // 3. During second fetch after connection failure
+            verify(callback, times(3)).newConnection(any());
+
+            // Verify the subscription was created:
+            // - Twice with first connection (in handleSplitsChanges and first fetch)
+            // - Once with second connection (in second fetch)
+            verify(mockJs, times(2)).subscribe(eq(subject), any(PullSubscribeOptions.class));
+            verify(mockJs2, times(1)).subscribe(eq(subject), any(PullSubscribeOptions.class));
+        }
+        catch(Exception e){
+            throw e;
+        }
+    }
+
+
+
+    /**
+     * Helper method to create NatsJetStreamSourceConfiguration using reflection
+     */
+    private static NatsJetStreamSourceConfiguration createSourceConfig(
+            String consumerName,
+            int maxFetchRecords,
+            boolean enableAutoAckMessage,
+            Duration fetchTimeout,
+            Duration autoAckInterval,
+            int maxPendingMessages,
+            Duration maxWaitingTime,
+            Boundedness boundedness) {
+        try {
+            Constructor<NatsJetStreamSourceConfiguration> constructor = 
+                NatsJetStreamSourceConfiguration.class.getDeclaredConstructor(
+                    String.class,
+                    int.class,
+                    boolean.class,
+                    Duration.class,
+                    Duration.class,
+                    int.class,
+                    Duration.class,
+                    Boundedness.class
+                );
+            constructor.setAccessible(true);
+            return constructor.newInstance(
+                consumerName,
+                maxFetchRecords,
+                enableAutoAckMessage,
+                fetchTimeout,
+                autoAckInterval,
+                maxPendingMessages,
+                maxWaitingTime,
+                boundedness
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create NatsJetStreamSourceConfiguration", e);
+        }
+    }
+}

--- a/src/test/java/io/synadia/io/synadia/flink/v0/testutils/NatsSourceTestEnv.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/testutils/NatsSourceTestEnv.java
@@ -1,0 +1,45 @@
+package io.synadia.io.synadia.flink.v0.testutils;
+
+import io.nats.client.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NatsSourceTestEnv {
+    private static final Logger LOG = LoggerFactory.getLogger(NatsSourceTestEnv.class);
+    
+    protected static Connection natsConnection;
+    protected static JetStreamManagement jsm;
+    public static final int NUM_MESSAGES_PER_SUBJECT = 10;
+
+    @BeforeAll
+    public static void prepare() throws Exception {
+        LOG.info("-------------------------------------------------------------------------");
+        LOG.info("    Starting NatsSourceTestEnv ");
+        LOG.info("-------------------------------------------------------------------------");
+
+        natsConnection = Nats.connect(Options.DEFAULT_URL);
+        jsm = natsConnection.jetStreamManagement();
+    }
+
+
+    protected static void publishTestMessages(String subject, int numMessages) throws Exception {
+        JetStream js = natsConnection.jetStream();
+        for (int i = 0; i < numMessages; i++) {
+            js.publish(subject, String.valueOf(i).getBytes());
+        }
+    }
+
+
+    @AfterAll
+    public static void shutDownServices() throws Exception {
+        LOG.info("-------------------------------------------------------------------------");
+        LOG.info("    Shutting down NatsSourceTestEnv ");
+        LOG.info("-------------------------------------------------------------------------");
+
+        if (natsConnection != null) {
+            natsConnection.close();
+        }
+    }
+} 


### PR DESCRIPTION
Connections are currently established in the fetch method of the split reader. This method operates in a separate thread, and the connections are terminated when the split reader is closed.

However, acknowledgments (acks) are processed with a slight delay. By the time an acknowledgment is triggered, the split reader might already have been closed. Since message acknowledgments (Message.Ack) rely on the same connection that was used to receive the message, closing the connection prematurely causes the acknowledgment to fail.

To resolve this, connections need to remain active beyond the lifecycle of the split reader. They should only be closed when the source reader itself is closed to ensure all acknowledgments are successfully processed.

This behavior can be observed by running the testJsSourceBounded test case.

Test Case Observations:
The output log below demonstrates the issue:

```
> Task :compileJava
> Task :processResources UP-TO-DATE
> Task :classes
> Task :compileTestJava
> Task :processTestResources UP-TO-DATE
> Task :testClasses
> Task :test
13:42:07:243 [INFO] NatsSubjectSplitReader - Register split [Subject: sub-zPryy31KwQ] consumer for current reader.
13:42:12:273 [INFO] NatsSourceFetcherManager - Closing Fetcher
13:42:12:277 [INFO] NatsSubjectSplitReader -  Closing SplitReader
13:42:15:479 [ERROR] NatsJetStreamSourceReader - Failed to acknowledge cursors for checkpoint 1
java.lang.IllegalStateException: Connection is Closed
	at io.nats.client.impl.NatsConnection.publishInternal(NatsConnection.java:979)
	at io.nats.client.impl.NatsConnection.publish(NatsConnection.java:935)
	at io.nats.client.impl.NatsJetStreamMessage.ackReply(NatsJetStreamMessage.java:118)
	at io.nats.client.impl.NatsJetStreamMessage.ack(NatsJetStreamMessage.java:38)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at io.synadia.flink.v0.source.reader.NatsSubjectSplitReader.notifyCheckpointComplete(NatsSubjectSplitReader.java:142)
	at io.synadia.flink.v0.source.reader.NatsSourceFetcherManager.triggerAcknowledge(NatsSourceFetcherManager.java:115)
	at io.synadia.flink.v0.source.reader.NatsSourceFetcherManager.acknowledgeMessages(NatsSourceFetcherManager.java:104)
	at io.synadia.flink.v0.source.reader.NatsJetStreamSourceReader.notifyCheckpointComplete(NatsJetStreamSourceReader.java:96)
	at org.apache.flink.streaming.api.operators.SourceOperator.notifyCheckpointComplete(SourceOperator.java:551)
	at org.apache.flink.streaming.runtime.tasks.StreamOperatorWrapper.notifyCheckpointComplete(StreamOperatorWrapper.java:104)
	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.notifyCheckpointComplete(RegularOperatorChain.java:145)
	at org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinatorImpl.notifyCheckpoint(SubtaskCheckpointCoordinatorImpl.java:467)
	at org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinatorImpl.notifyCheckpointComplete(SubtaskCheckpointCoordinatorImpl.java:400)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.notifyCheckpointComplete(StreamTask.java:1430)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.lambda$notifyCheckpointCompleteAsync$16(StreamTask.java:1371)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.lambda$notifyCheckpointOperation$19(StreamTask.java:1410)
	at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.runThrowing(StreamTaskActionExecutor.java:50)
	at org.apache.flink.streaming.runtime.tasks.mailbox.Mail.run(Mail.java:90)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMail(MailboxProcessor.java:398)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.processMailsWhenDefaultActionUnavailable(MailboxProcessor.java:367)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.processMail(MailboxProcessor.java:352)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMailboxLoop(MailboxProcessor.java:229)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.runMailboxLoop(StreamTask.java:839)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:788)
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:952)
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:931)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:745)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:562)
	at java.base/java.lang.Thread.run(Thread.java:829)
13:42:15:527 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:527 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:527 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:520 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:523 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:523 [INFO] NatsJetStreamSourceReader - Closing Source Reader
13:42:15:547 [INFO] NatsJetStreamSourceReader - Closing Source Reader
```

Here, the test fails because the connection was closed as soon as the split reader shut down.

This PR moves the connections back to the source reader and get closed only when source reader closes.