### PR TITLE
fixes consumer 409 deleted

### DIFF
--- a/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java
@@ -182,6 +182,14 @@ public class JsSourceTests extends TestBase {
 
             // Step 9: Cleanup
             env.close();
+
+            // wait for the execution environment to finish
+            // flink will take time to close it resources
+            // if this is not done, code will attempt to delete jet stream
+            // while one of the fetcher threads might be polling
+            Thread.sleep(5_000L);
+
+            // delete stream now
             jsm.deleteStream(streamName);
         });
     }


### PR DESCRIPTION
The Flink `env.close()` method takes time to release resources properly. Therefore, it’s important to introduce a delay after calling `env.close()` to ensure all resources are fully closed before deleting the stream. Without this delay, there is a risk that a fetcher thread may attempt to poll messages immediately after the stream has been deleted, leading to potential issues.