### PR TITLE
Clear source reader state on checkpointing

### DIFF
--- a/src/main/java/io/synadia/flink/v0/source/reader/NatsJetStreamSourceReader.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/NatsJetStreamSourceReader.java
@@ -114,7 +114,7 @@ public class NatsJetStreamSourceReader<OutputT>
                 cursorsToCommit.computeIfAbsent(checkpointId, id -> new HashMap<>());
         // Put the cursors of the active splits.
         for (NatsSubjectSplit split : splits) {
-            cursors.put(split.getSubject(), split.getCurrentMessages());
+            cursors.put(split.splitId(), split.getCurrentMessages());
         }
         // Put cursors of all the finished splits.
         cursors.putAll(cursorsOfFinishedSplits);
@@ -162,7 +162,7 @@ public class NatsJetStreamSourceReader<OutputT>
         // So the checkpoint didn't really happen, so we just pass a fake checkpoint id.
         List<NatsSubjectSplit> splits = super.snapshotState(1L);
         for (NatsSubjectSplit split : splits) {
-            cursors.put(split.getSubject(), split.getCurrentMessages());
+            cursors.put(split.splitId(), split.getCurrentMessages());
         }
 
         try {

--- a/src/main/java/io/synadia/flink/v0/source/reader/NatsSourceFetcherManager.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/NatsSourceFetcherManager.java
@@ -97,21 +97,22 @@ public class NatsSourceFetcherManager
         LOG.debug("Acknowledge messages {}", cursorsToCommit);
 
         for (Map.Entry<String, List<Message>> entry : cursorsToCommit.entrySet()) {
-            String partition = entry.getKey();
-            SplitFetcher<Message, NatsSubjectSplit> fetcher =
-                    getOrCreateFetcher(partition);
-            triggerAcknowledge(fetcher, partition, entry.getValue());
+            LOG.debug("No of messages to ack: {}", entry.getValue().size());
+
+            String splitId = entry.getKey();
+            SplitFetcher<Message, NatsSubjectSplit> fetcher = getOrCreateFetcher(splitId);
+            triggerAcknowledge(fetcher, splitId, entry.getValue());
         }
     }
 
     private void triggerAcknowledge(
             SplitFetcher<Message, NatsSubjectSplit> splitFetcher,
-            String partition,
+            String splitId,
             List<Message> messages)
             throws Exception { //TODO Change to nats specific exception
         NatsSubjectSplitReader splitReader =
                 (NatsSubjectSplitReader) splitFetcher.getSplitReader();
-        splitReader.notifyCheckpointComplete(partition, messages);
+        splitReader.notifyCheckpointComplete(splitId, messages);
         startFetcher(splitFetcher);
     }
 

--- a/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplit.java
+++ b/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplit.java
@@ -7,6 +7,7 @@ import io.nats.client.Message;
 import org.apache.flink.api.connector.source.SourceSplit;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class NatsSubjectSplit implements SourceSplit {
@@ -21,7 +22,11 @@ public class NatsSubjectSplit implements SourceSplit {
 
     public NatsSubjectSplit(String subject, List<Message> currentMessages){
         this.subject = subject;
-        this.currentMessages = new ArrayList<>();
+
+        // Synchronization is required because record emission and snapshotState occur on different threads.
+        // we need to flush this list once state is captured since we do ack-ing once state is captured.
+        this.currentMessages = Collections.synchronizedList(new ArrayList<>());
+
         if (currentMessages != null && !currentMessages.isEmpty()) {
             this.currentMessages.addAll(currentMessages);
         }

--- a/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitState.java
+++ b/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitState.java
@@ -3,6 +3,11 @@
 
 package io.synadia.flink.v0.source.split;
 
+import io.nats.client.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class NatsSubjectSplitState {
 
     private final NatsSubjectSplit split;
@@ -11,8 +16,14 @@ public class NatsSubjectSplitState {
         this.split = split;
     }
 
+    // this method gets called on every snapshot done by flink
+    // flush the list to remove the last set of messages
+    // either they have already passed/failed while ack-ing
+    // no need to maintain it anymore
     public NatsSubjectSplit toNatsSubjectSplit() {
-        return new NatsSubjectSplit(split.getSubject(), split.getCurrentMessages());
+        List<Message> messages = new ArrayList<>(split.getCurrentMessages());
+        split.getCurrentMessages().clear();
+        return new NatsSubjectSplit(split.getSubject(), messages);
     }
 
     public NatsSubjectSplit getSplit() {

--- a/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitState.java
+++ b/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitState.java
@@ -20,6 +20,8 @@ public class NatsSubjectSplitState {
     // flush the list to remove the last set of messages
     // either they will pass or fail while ack-ing
     // no need to maintain it anymore
+    // we only ack the messages only once they are check-pointed
+    // so even if they fail by some reason in later stages, they will be re-delivered by NATS
     public NatsSubjectSplit toNatsSubjectSplit() {
         List<Message> messages = new ArrayList<>(split.getCurrentMessages());
 

--- a/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitState.java
+++ b/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitState.java
@@ -3,11 +3,6 @@
 
 package io.synadia.flink.v0.source.split;
 
-import io.nats.client.Message;
-
-import java.util.ArrayList;
-import java.util.List;
-
 public class NatsSubjectSplitState {
 
     private final NatsSubjectSplit split;
@@ -16,20 +11,8 @@ public class NatsSubjectSplitState {
         this.split = split;
     }
 
-    // this method gets called on every snapshot done by flink
-    // flush the list to remove the last set of messages
-    // either they will pass or fail while ack-ing
-    // no need to maintain it anymore
-    // we only ack the messages only once they are check-pointed
-    // so even if they fail by some reason in later stages, they will be re-delivered by NATS
     public NatsSubjectSplit toNatsSubjectSplit() {
-        List<Message> messages = new ArrayList<>(split.getCurrentMessages());
-
-        // this resets the state to hold new messages
-        split.getCurrentMessages().clear();
-
-        // return the messages for acknowledgment and store them in state backends
-        return new NatsSubjectSplit(split.getSubject(), messages);
+        return split;
     }
 
     public NatsSubjectSplit getSplit() {

--- a/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitState.java
+++ b/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitState.java
@@ -18,11 +18,15 @@ public class NatsSubjectSplitState {
 
     // this method gets called on every snapshot done by flink
     // flush the list to remove the last set of messages
-    // either they have already passed/failed while ack-ing
+    // either they will pass or fail while ack-ing
     // no need to maintain it anymore
     public NatsSubjectSplit toNatsSubjectSplit() {
         List<Message> messages = new ArrayList<>(split.getCurrentMessages());
+
+        // this resets the state to hold new messages
         split.getCurrentMessages().clear();
+
+        // return the messages for acknowledgment and store them in state backends
         return new NatsSubjectSplit(split.getSubject(), messages);
     }
 


### PR DESCRIPTION
This PR addresses the memory issue present in the main branch where the state maintained per source reader grows continuously with each call to the `snapshotState` method. In Flink, this method is invoked to take a snapshot of the state. However, the current implementation does not clear the messages from the state, even though they are acknowledged during the `notifyCheckpointComplete` phase.

To resolve this, we ensure that the state is cleared in a thread-safe manner, preventing unnecessary memory consumption.

**Below are logs illustrating the issue:**

```
2025-01-16 16:24:01:223+0530 [main] [DEBUG] NatsJetStreamSource - a0xg | Boundedness
2025-01-16 16:24:03:238+0530 [jobmanager-io-thread-1] [DEBUG] NatsJetStreamSource - 3ElD | getSplitSerializer
2025-01-16 16:24:03:265+0530 [jobmanager-io-thread-1] [DEBUG] NatsJetStreamSource - 3ElD | getEnumeratorCheckpointSerializer
2025-01-16 16:24:03:340+0530 [flink-akka.actor.default-dispatcher-6] [DEBUG] NatsJetStreamSource - 3ElD | createEnumerator
2025-01-16 16:24:03:341+0530 [flink-akka.actor.default-dispatcher-6] [DEBUG] NatsJetStreamSource - 3ElD | restoreEnumerator
2025-01-16 16:24:03:567+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSource - 3ElD | getSplitSerializer
2025-01-16 16:24:03:631+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - a0xg-MCO02JyXx7 | start
2025-01-16 16:24:03:644+0530 [Source Data Fetcher for Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSubjectSplitReader - a0xg-MCO02JyXzf | handleSplitsChanges SplitAddition:[[[Subject: example-source]]]
2025-01-16 16:24:03:653+0530 [Source Data Fetcher for Source: nats-source-input -> Sink: Writer (1/1)#0] [INFO] NatsSubjectSplitReader - Register split [Subject: example-source] consumer for current reader.
2025-01-16 16:24:08:933+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - a0xg-MCO02JyXx7 | Committing cursors for checkpoint 1
2025-01-16 16:24:08:933+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 1000
2025-01-16 16:24:08:935+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - a0xg-MCO02JyXx7 | Successfully acknowledge cursors for checkpoint 1
2025-01-16 16:24:18:898+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - a0xg-MCO02JyXx7 | Committing cursors for checkpoint 2
2025-01-16 16:24:18:898+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 1410
2025-01-16 16:24:18:902+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - a0xg-MCO02JyXx7 | Successfully acknowledge cursors for checkpoint 2
2025-01-16 16:24:28:891+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - a0xg-MCO02JyXx7 | Committing cursors for checkpoint 3
2025-01-16 16:24:28:891+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 2010
2025-01-16 16:24:28:893+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - a0xg-MCO02JyXx7 | Successfully acknowledge cursors for checkpoint 3
2025-01-16 16:24:38:889+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - a0xg-MCO02JyXx7 | Committing cursors for checkpoint 4
2025-01-16 16:24:38:889+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 2810
```


As seen in the logs, the number of messages to acknowledge keeps increasing with every fetch from the stream. Since this is an unbounded stream, the data retained in memory will continue to grow, leading to potential memory exhaustion.

### After PR Fix:

**Logs:**

```
2025-01-16 16:30:12:325+0530 [main] [DEBUG] NatsJetStreamSource - OU3Z | Boundedness
2025-01-16 16:30:13:436+0530 [jobmanager-io-thread-1] [DEBUG] NatsJetStreamSource - 61qx | getSplitSerializer
2025-01-16 16:30:13:441+0530 [jobmanager-io-thread-1] [DEBUG] NatsJetStreamSource - 61qx | getEnumeratorCheckpointSerializer
2025-01-16 16:30:13:476+0530 [flink-akka.actor.default-dispatcher-7] [DEBUG] NatsJetStreamSource - 61qx | createEnumerator
2025-01-16 16:30:13:476+0530 [flink-akka.actor.default-dispatcher-7] [DEBUG] NatsJetStreamSource - 61qx | restoreEnumerator
2025-01-16 16:30:13:614+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSource - 61qx | getSplitSerializer
2025-01-16 16:30:13:646+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | start
2025-01-16 16:30:13:652+0530 [Source Data Fetcher for Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSubjectSplitReader - OU3Z-dZWmh1o63h | handleSplitsChanges SplitAddition:[[[Subject: example-source]]]
2025-01-16 16:30:13:657+0530 [Source Data Fetcher for Source: nats-source-input -> Sink: Writer (1/1)#0] [INFO] NatsSubjectSplitReader - Register split [Subject: example-source] consumer for current reader.
2025-01-16 16:30:20:793+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Committing cursors for checkpoint 1
2025-01-16 16:30:20:794+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 1000
2025-01-16 16:30:20:797+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Successfully acknowledge cursors for checkpoint 1
2025-01-16 16:30:30:740+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Committing cursors for checkpoint 2
2025-01-16 16:30:30:740+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 1000
2025-01-16 16:30:30:747+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Successfully acknowledge cursors for checkpoint 2
2025-01-16 16:30:40:736+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Committing cursors for checkpoint 3
2025-01-16 16:30:40:737+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 1000
2025-01-16 16:30:40:739+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Successfully acknowledge cursors for checkpoint 3
2025-01-16 16:30:50:735+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Committing cursors for checkpoint 4
2025-01-16 16:30:50:736+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 1000
2025-01-16 16:30:50:738+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Successfully acknowledge cursors for checkpoint 4
2025-01-16 16:31:00:735+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Committing cursors for checkpoint 5
2025-01-16 16:31:00:735+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 293
2025-01-16 16:31:00:736+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Successfully acknowledge cursors for checkpoint 5
2025-01-16 16:31:10:740+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Committing cursors for checkpoint 6
2025-01-16 16:31:10:740+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 0
2025-01-16 16:31:10:740+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Successfully acknowledge cursors for checkpoint 6
2025-01-16 16:31:20:736+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Committing cursors for checkpoint 7
2025-01-16 16:31:20:736+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsSourceFetcherManager - No of messages to ack: 0
2025-01-16 16:31:20:736+0530 [Source: nats-source-input -> Sink: Writer (1/1)#0] [DEBUG] NatsJetStreamSourceReader - OU3Z-dZWmh1o60N | Successfully acknowledge cursors for checkpoint 7
```


The logs confirm that the state is now cleared correctly, ensuring memory usage remains efficient and does not grow indefinitely. 

**PS:** _I had some 4293 messages and you can see the state is 0 once it stops receiving new messages._

Fixes #30 