### PR TITLE
support replyTo for users to ack

### DIFF
--- a/src/main/java/io/synadia/flink/v0/emitter/NatsRecordEmitter.java
+++ b/src/main/java/io/synadia/flink/v0/emitter/NatsRecordEmitter.java
@@ -8,11 +8,15 @@ import io.synadia.flink.v0.payload.PayloadDeserializer;
 import io.synadia.flink.v0.source.split.NatsSubjectSplitState;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NatsRecordEmitter<OutputT>
         implements RecordEmitter<Message, OutputT, NatsSubjectSplitState> {
 
     private final PayloadDeserializer<OutputT> payloadDeserializer;
+    private static final Logger LOG = LoggerFactory.getLogger(NatsRecordEmitter.class);
 
     public NatsRecordEmitter(PayloadDeserializer<OutputT> payloadDeserializer) {
         this.payloadDeserializer = payloadDeserializer;
@@ -24,8 +28,14 @@ public class NatsRecordEmitter<OutputT>
                            NatsSubjectSplitState splitState)
             throws Exception {
 
-        // Deserialize the message and send it to output.
-        output.collect(payloadDeserializer.getObject(splitState.getSplit().getSubject(), element.getData(), element.getHeaders()));
+        try {
+            // Deserialize the message and send it to output.
+            output.collect(payloadDeserializer.getObject(splitState.getSplit().getSubject(), element.getData(), element.getHeaders(), element.getReplyTo()));
+        } catch (Exception e) {
+            LOG.error("Failed to deserialize message", e);
+            throw new FlinkRuntimeException("Failed to deserialize message", e);
+        }
+
         splitState.getSplit().getCurrentMessages().add(element);
     }
 }

--- a/src/main/java/io/synadia/flink/v0/payload/ByteArrayPayloadDeserializer.java
+++ b/src/main/java/io/synadia/flink/v0/payload/ByteArrayPayloadDeserializer.java
@@ -15,7 +15,7 @@ public class ByteArrayPayloadDeserializer implements PayloadDeserializer<Byte[]>
     private static final long serialVersionUID = 1L;
 
     @Override
-    public Byte[] getObject(String subject, byte[] input, Headers headers) {
+    public Byte[] getObject(String subject, byte[] input, Headers headers, String replyTo) {
         int len = input == null ? 0 : input.length;
         Byte[] object = new Byte[len];
         for (int x = 0; x < len; x++) {

--- a/src/main/java/io/synadia/flink/v0/payload/Payload.java
+++ b/src/main/java/io/synadia/flink/v0/payload/Payload.java
@@ -2,17 +2,44 @@ package io.synadia.flink.v0.payload;
 
 import io.nats.client.impl.Headers;
 
-public class Payload<InputT> {
-    public final InputT payload;
-    public final Headers headers;
+import java.io.Serializable;
+import java.util.*;
 
-    public Payload(InputT payload) {
-        this.payload = payload;
+/**
+ * Payload is a generic class that holds the data, headers and replyTo information.
+ *
+ * @param <InputT> the data type
+ */
+public class Payload<InputT> implements Serializable {
+    public final InputT data;
+
+    public final Map<String, List<String>> headers;
+    public final String replyTo;
+
+    public Payload() {
+        this.data = null;
         this.headers = null;
+        this.replyTo = null;
     }
 
-    public Payload(InputT payload, Headers headers) {
-        this.payload = payload;
+    public Payload(InputT data, Map<String, List<String>> headers, String replyTo) {
+        this.data = data;
         this.headers = headers;
+        this.replyTo = replyTo;
+    }
+
+    @Override
+    public String toString() {
+        Set<String> keys = new HashSet<>();
+        if (headers != null) {
+            keys = headers.keySet();
+        }
+
+        return "Payload{" +
+                "data=" + data +
+                ", headers=" + keys +
+                ", replyTo='" + replyTo + '\'' +
+                '}';
     }
 }
+

--- a/src/main/java/io/synadia/flink/v0/payload/PayloadDeserializer.java
+++ b/src/main/java/io/synadia/flink/v0/payload/PayloadDeserializer.java
@@ -18,5 +18,5 @@ public interface PayloadDeserializer<OutputT> extends Serializable, ResultTypeQu
      * @param headers the message headers
      * @return the output object
      */
-    OutputT getObject(String subject, byte[] input, Headers headers);
+    OutputT getObject(String subject, byte[] input, Headers headers, String replyTo);
 }

--- a/src/main/java/io/synadia/flink/v0/payload/StringPayloadDeserializer.java
+++ b/src/main/java/io/synadia/flink/v0/payload/StringPayloadDeserializer.java
@@ -53,7 +53,7 @@ public class StringPayloadDeserializer implements PayloadDeserializer<String> {
      * {@inheritDoc}
      */
     @Override
-    public String getObject(String subject, byte[] input, Headers headers) {
+    public String getObject(String subject, byte[] input, Headers headers, String replyTo) {
         if (input == null || input.length == 0) {
             return "";
         }

--- a/src/main/java/io/synadia/flink/v0/source/reader/NatsSourceReader.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/NatsSourceReader.java
@@ -71,7 +71,7 @@ public class NatsSourceReader<OutputT> implements SourceReader<OutputT, NatsSubj
             LOG.debug("{} | pollNext no message NOTHING_AVAILABLE", id);
             return InputStatus.NOTHING_AVAILABLE;
         }
-        output.collect(payloadDeserializer.getObject(m.getSubject(), m.getData(), m.getHeaders()));
+        output.collect(payloadDeserializer.getObject(m.getSubject(), m.getData(), m.getHeaders(), m.getReplyTo()));
         InputStatus is = messages.isEmpty() ? InputStatus.NOTHING_AVAILABLE : InputStatus.MORE_AVAILABLE;
         LOG.debug("{} | pollNext had message, then {}", id, is);
         return is;

--- a/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
@@ -23,14 +23,13 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import static io.synadia.flink.v0.utils.ConnectionContext.ACK_BODY_BYTES;
 import static io.synadia.flink.v0.utils.MiscUtils.generatePrefixedId;
 
 public class NatsSubjectSplitReader
         implements SplitReader<Message, NatsSubjectSplit> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NatsSubjectSplitReader.class);
-
-    private static final byte[] ACK_BODY_BYTES = AckType.AckAck.bodyBytes(-1);
 
     private final String id;
     private final ConnectionFactory connectionFactory;

--- a/src/main/java/io/synadia/flink/v0/utils/ConnectionContext.java
+++ b/src/main/java/io/synadia/flink/v0/utils/ConnectionContext.java
@@ -7,10 +7,13 @@ import io.nats.client.Connection;
 import io.nats.client.JetStream;
 import io.nats.client.JetStreamManagement;
 import io.nats.client.JetStreamOptions;
+import io.nats.client.impl.AckType;
 
 import java.io.IOException;
 
 public class ConnectionContext {
+    public static final byte[] ACK_BODY_BYTES = AckType.AckAck.bodyBytes(-1);
+
     public final Connection connection;
     public final JetStreamManagement jsm;
     public final JetStream js;

--- a/src/test/java/io/synadia/io/synadia/flink/TestBase.java
+++ b/src/test/java/io/synadia/io/synadia/flink/TestBase.java
@@ -8,24 +8,31 @@ import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
 import io.synadia.flink.v0.payload.ByteArrayPayloadSerializer;
+import io.synadia.flink.v0.payload.Payload;
 import io.synadia.flink.v0.payload.StringPayloadSerializer;
 import io.synadia.flink.v0.sink.NatsJetStreamSink;
 import io.synadia.flink.v0.sink.NatsJetStreamSinkBuilder;
 import io.synadia.flink.v0.sink.NatsSink;
 import io.synadia.flink.v0.sink.NatsSinkBuilder;
+import io.synadia.flink.v0.utils.ConnectionContext;
+import io.synadia.flink.v0.utils.ConnectionFactory;
 import nats.io.ConsoleOutput;
 import nats.io.NatsServerRunner;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.connector.file.src.FileSource;
 import org.apache.flink.connector.file.src.reader.TextLineInputFormat;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.Collector;
 
 import java.io.*;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.logging.Level;
+
+import static io.synadia.flink.v0.utils.ConnectionContext.ACK_BODY_BYTES;
 
 public class TestBase {
     public static final String PLAIN_ASCII = "hello world ascii";
@@ -312,5 +319,44 @@ public class TestBase {
         Object outObject = objectInputStream.readObject();
         objectInputStream.close();
         return outObject;
+    }
+
+    // this FlatMapFunction requires members to be serializable, Nats connection is not serializable
+    // AckMessageFunction acks messages in a sequence up to a stopAtSeq
+    public static class AckMessageFunction implements FlatMapFunction<Payload<byte[]>, Payload<byte[]>> {
+        public final ConnectionFactory connectionFactory;
+        private int currSeq;
+        private final int stopAtSeq;
+
+        public AckMessageFunction(ConnectionFactory connectionFactory, int currSeq, int stopAtSeq) throws IllegalArgumentException {
+            this.connectionFactory = connectionFactory;
+            if (currSeq < 0 || currSeq > stopAtSeq) {
+                throw new IllegalArgumentException("currSeq must be less than stopAtSeq");
+            }
+
+            this.currSeq = currSeq;
+            this.stopAtSeq = stopAtSeq;
+        }
+
+        @Override
+        public void flatMap(Payload<byte[]> p, Collector<Payload<byte[]>> out) throws Exception {
+            if (currSeq > stopAtSeq) {
+                return;
+            }
+
+            assert p.replyTo != null;
+            ConnectionContext context = connectionFactory.connectContext();
+
+            // introduce random delays to simulate user acking at different intervals ranging from 100-500 ms
+            long sleep = (long) (Math.random() * 400) + 100;
+
+            System.out.println(p);
+            System.out.println("sleeping for " + sleep + "ms");
+
+            Thread.sleep(sleep);
+
+            context.connection.publish(p.replyTo, ACK_BODY_BYTES);
+            currSeq++;
+        }
     }
 }

--- a/src/test/java/io/synadia/io/synadia/flink/WordCountDeserializer.java
+++ b/src/test/java/io/synadia/io/synadia/flink/WordCountDeserializer.java
@@ -10,7 +10,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 public class WordCountDeserializer implements PayloadDeserializer<WordCount> {
     @Override
-    public WordCount getObject(String subject, byte[] input, Headers headers) {
+    public WordCount getObject(String subject, byte[] input, Headers headers, String replyTo) {
         return new WordCount(input);
     }
 

--- a/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java
@@ -5,17 +5,19 @@ package io.synadia.io.synadia.flink.v0;
 
 import io.nats.client.*;
 import io.nats.client.api.*;
+import io.nats.client.impl.Headers;
+import io.synadia.flink.v0.payload.*;
 import io.synadia.flink.v0.source.NatsJetStreamSource;
 import io.synadia.flink.v0.source.NatsJetStreamSourceBuilder;
-import io.synadia.flink.v0.payload.PayloadDeserializer;
-import io.synadia.flink.v0.payload.StringPayloadDeserializer;
-import io.synadia.flink.v0.payload.StringPayloadSerializer;
 import io.synadia.flink.v0.sink.NatsSink;
 import io.synadia.flink.v0.sink.NatsSinkBuilder;
+import io.synadia.flink.v0.utils.ConnectionFactory;
 import io.synadia.io.synadia.flink.TestBase;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -24,12 +26,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
-import static io.nats.client.api.ConsumerConfiguration.INTEGER_UNSET;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class JsSourceTests extends TestBase {
@@ -45,6 +43,86 @@ public class JsSourceTests extends TestBase {
                 sleep(delay);
             }
         }
+    }
+
+    static class PayloadBytesDeserializer implements PayloadDeserializer<Payload<byte[]>> {
+
+        @Override
+        public Payload<byte[]> getObject(String subject, byte[] data, Headers headers, String replyTo) {
+            Map<String, List<String>> newHeaders = new HashMap<>();
+
+            // collect required information from the headers
+            if (headers != null) {
+                headers.forEach(newHeaders::put);
+            }
+
+            return new Payload<>(data, newHeaders, replyTo);
+        }
+
+        @Override
+        public TypeInformation<Payload<byte[]>> getProducedType() {
+            return TypeInformation.of(new TypeHint<Payload<byte[]>>() {});
+        }
+    }
+
+    @Test
+    public void testReplyToBounded() throws Exception {
+        String sourceSubject = random("sub");
+        String streamName = random("strm");
+        String consumerName = random("con");
+
+        runInServer(true, (nc, url) -> {
+            JetStreamManagement jsm = nc.jetStreamManagement();
+            JetStream js = jsm.jetStream();
+
+            // Step 1: Create the source stream and publish messages
+            createStream(jsm, streamName, sourceSubject);
+            publish(js, sourceSubject, 10);
+
+            // Step 2: Create a JetStream consumer
+            createExplicitConsumer(jsm, streamName, sourceSubject, consumerName);
+
+            // Step 3: Configure the NATS JetStream Source
+            Properties connectionProperties = defaultConnectionProperties(url);
+            PayloadBytesDeserializer deserializer = new PayloadBytesDeserializer();
+            NatsJetStreamSourceBuilder<Payload<byte[]>> builder =
+                    new NatsJetStreamSourceBuilder<Payload<byte[]>>()
+                            .subjects(sourceSubject)
+                            .payloadDeserializer(deserializer)
+                            .connectionProperties(connectionProperties)
+                            .consumerName(consumerName)
+                            .maxFetchRecords(100)
+                            .maxFetchTime(Duration.ofSeconds(5))
+                            .boundness(Boundedness.BOUNDED);
+
+            // Step 4: Set up Flink Streaming Environment
+            NatsJetStreamSource<Payload<byte[]>> natsSource = builder.build();
+            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            DataStream<Payload<byte[]>> ds = env.fromSource(natsSource, WatermarkStrategy.noWatermarks(), "nats-source-input");
+
+            // Step 5: Process the messages and ack them
+            ConnectionFactory connectionFactory = new ConnectionFactory(connectionProperties);
+            ds.flatMap(new AckMessageFunction(connectionFactory, 1, 5));
+
+            // Step 6: Set Flink restart strategy and execute the job asynchronously
+            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, Time.seconds(5)));
+            env.executeAsync("testReplyToBounded");
+
+            // Step 7: Wait for processing to complete
+            Thread.sleep(12_000);
+
+            // Step 8: Get ConsumerInfo and validate
+            ConsumerInfo consumerInfo = jsm.getConsumerInfo(streamName, consumerName);
+            assertEquals(5, consumerInfo.getNumAckPending(), "5/10 messages should be acked.");
+
+            // Step 9: Cleanup and validation
+            env.close();
+
+            // wait for the execution environment to finish
+            Thread.sleep(7_000);
+            jsm.deleteStream(streamName);
+            nc.close();
+        });
     }
 
     @Test
@@ -147,7 +225,7 @@ public class JsSourceTests extends TestBase {
             // Source: Read from NATS
             DataStream<String> ds = env.fromSource(builder.build(), WatermarkStrategy.noWatermarks(), "nats-source-input");
 
-            // Step 4: Setup a Dispatcher to listen to the sink subject and capture messages
+            // Step 4: Set up a Dispatcher to listen to the sink subject and capture messages
             Dispatcher d = nc.createDispatcher();
             d.subscribe(sinkSubject, syncList::add);
 
@@ -202,6 +280,16 @@ public class JsSourceTests extends TestBase {
             .build();
         jsm.addOrUpdateConsumer(streamName, cc);
         return cc;
+    }
+
+    private static void createExplicitConsumer(JetStreamManagement jsm, String streamName, String sourceSubject, String consumerName) throws IOException, JetStreamApiException {
+        ConsumerConfiguration cc = ConsumerConfiguration.builder()
+                .durable(consumerName)
+                .ackPolicy(AckPolicy.Explicit)
+                .filterSubject(sourceSubject)
+                .build();
+
+        jsm.addOrUpdateConsumer(streamName, cc);
     }
 
     private static void createStream(JetStreamManagement jsm, String streamName, String sourceSubject) throws IOException, JetStreamApiException {

--- a/src/test/java/io/synadia/io/synadia/flink/v0/SerializersDeserializersTests.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/SerializersDeserializersTests.java
@@ -93,25 +93,25 @@ public class SerializersDeserializersTests extends TestBase {
 
         String subject = "validateStringPayload";
         byte[] bytes = PLAIN_ASCII.getBytes();
-        assertEquals(PLAIN_ASCII, spdAscii.getObject(subject, bytes, null));
-        assertEquals(PLAIN_ASCII, spdUtf8.getObject(subject, bytes, null));
+        assertEquals(PLAIN_ASCII, spdAscii.getObject(subject, bytes, null, null));
+        assertEquals(PLAIN_ASCII, spdUtf8.getObject(subject, bytes, null, null));
 
         bytes = spsAscii.getBytes(PLAIN_ASCII);
-        assertEquals(PLAIN_ASCII, spdAscii.getObject(subject, bytes, null));
-        assertEquals(PLAIN_ASCII, spdUtf8.getObject(subject, bytes, null));
+        assertEquals(PLAIN_ASCII, spdAscii.getObject(subject, bytes, null, null));
+        assertEquals(PLAIN_ASCII, spdUtf8.getObject(subject, bytes, null, null));
 
         bytes = spsUtf8.getBytes(PLAIN_ASCII);
-        assertEquals(PLAIN_ASCII, spdAscii.getObject(subject, bytes, null));
-        assertEquals(PLAIN_ASCII, spdUtf8.getObject(subject, bytes, null));
+        assertEquals(PLAIN_ASCII, spdAscii.getObject(subject, bytes, null, null));
+        assertEquals(PLAIN_ASCII, spdUtf8.getObject(subject, bytes, null, null));
 
         for (String su : UTF8_TEST_STRINGS) {
             bytes = su.getBytes(StandardCharsets.UTF_8);
-            assertNotEquals(su, spdAscii.getObject(subject, bytes, null));
-            assertEquals(su, spdUtf8.getObject(subject, bytes, null));
+            assertNotEquals(su, spdAscii.getObject(subject, bytes, null, null));
+            assertEquals(su, spdUtf8.getObject(subject, bytes, null, null));
 
             bytes = spsUtf8.getBytes(su);
-            assertNotEquals(su, spdAscii.getObject(subject, bytes, null));
-            assertEquals(su, spdUtf8.getObject(subject, bytes, null));
+            assertNotEquals(su, spdAscii.getObject(subject, bytes, null, null));
+            assertEquals(su, spdUtf8.getObject(subject, bytes, null, null));
         }
     }
 
@@ -124,7 +124,7 @@ public class SerializersDeserializersTests extends TestBase {
             byte[] bytes = ser.getBytes(wc);
             WordCount wc2 = new WordCount(bytes);
             assertEquals(wc, wc2);
-            wc2 = dser.getObject("testCustomPayload", bytes, null);
+            wc2 = dser.getObject("testCustomPayload", bytes, null, null);
             assertEquals(wc, wc2);
         }
     }

--- a/src/test/java/io/synadia/io/synadia/flink/v0/SourceTests.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/SourceTests.java
@@ -137,10 +137,10 @@ public class SourceTests extends TestBase {
 
     static class HeaderAwareStringPayloadDeserializer extends StringPayloadDeserializer {
         @Override
-        public String getObject(String subject, byte[] input, Headers headers) {
+        public String getObject(String subject, byte[] input, Headers headers, String replyTo) {
             String hSubject = headers.getFirst("subject");
             String hNum = headers.getFirst("num");
-            return Publisher.dataString(hSubject, hNum);
+            return Publisher.dataString(hSubject, hNum) + "-" + replyTo;
         }
     }
 


### PR DESCRIPTION
### Reference PR: https://github.com/synadia-io/flink-connector-nats/pull/40

Enhancing Acknowledgment Flexibility

### Motivation

Currently, the system supports auto acknowledgment when check-pointing is disabled. However, we have a use case where users need the ability to independently acknowledge messages outside the constraints of checkpointing or scheduled acknowledgments. This is particularly important for tasks distributed across different task slots, where processing times may vary, and acknowledgment needs to be handled dynamically based on individual task completion.

### Key Features
                
1. **Exposing `replyTo` Field:**
                - The `replyTo` field is now exposed to users, enabling them to acknowledge messages manually.
	        - Users can use the `replyTo` field to publish an `+ACK` message to acknowledge the corresponding message.
	        
2. **Custom Acknowledgment Flow:**
                - Users can independently acknowledge messages as per their task-specific logic and timing.

### Example Use Case

1. A message is received by multiple task slots for parallel processing.
2. Each task slot processes the message independently and at varying durations.
3. The `replyTo` field allows tasks to send acknowledgments `+ACK` back to the server only after their processing is complete.

### Test Case

A new test case is added to validate user-driven acknowledgment at different intervals. The test simulates users acknowledging messages selectively.

**Logs**

`assertEquals(5, consumerInfo.getNumAckPending(), "5/10 messages should be acked.");`

Below is an example log output demonstrating acknowledgment behavior:

```
20:34:09:391 [INFO] NatsSubjectSplitReader - Register split [Subject: sub-cfcBFuLcT0] consumer for current reader.
Payload{payload=[B@651c1887, headers=null, replyTo='$JS.ACK.strm-cfcBFuLcX6.con-cfcBFuLcbC.1.1.1.1737299047298574000.9'}
sleeping for 4030ms
Payload{payload=[B@882164e, headers=null, replyTo='$JS.ACK.strm-cfcBFuLcX6.con-cfcBFuLcbC.1.2.2.1737299047299157000.8'}
sleeping for 2641ms
Payload{payload=[B@5a1c4062, headers=null, replyTo='$JS.ACK.strm-cfcBFuLcX6.con-cfcBFuLcbC.1.3.3.1737299047299383000.7'}
sleeping for 3171ms
Payload{payload=[B@ec36bfe, headers=null, replyTo='$JS.ACK.strm-cfcBFuLcX6.con-cfcBFuLcbC.1.4.4.1737299047299613000.6'}
sleeping for 1114ms
Payload{payload=[B@30b045e6, headers=null, replyTo='$JS.ACK.strm-cfcBFuLcX6.con-cfcBFuLcbC.1.5.5.1737299047299802000.5'}
sleeping for 4038ms
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.flink.api.java.ClosureCleaner (file:/Users/tilak.raj/.gradle/caches/modules-2/files-2.1/org.apache.flink/flink-core/1.17.2/98396f91b4bedabdea77a704cd23b80acfdf2ab6/flink-core-1.17.2.jar) to field java.util.Properties.serialVersionUID
WARNING: Please consider reporting this to the maintainers of org.apache.flink.api.java.ClosureCleaner
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
BUILD SUCCESSFUL in 1m 0s
5 actionable tasks: 2 executed, 3 up-to-date
8:35:06 PM: Execution finished ':test --tests "io.synadia.io.synadia.flink.v0.JsSourceTests.testReplyToBounded"'.
```

As seen above, the system processes 10 messages, but the user selectively acknowledges only 5 messages. The acknowledgment mechanism only sends acknowledgments for the 5 processed messages, ensuring fine-grained control.

### Summary

1. Enables independent acknowledgment by exposing the `replyTo` field.
2. Adds a test case demonstrating dynamic user acknowledgment at different intervals.
3. Improves the system’s flexibility and usability for real-world scenarios requiring manual acknowledgment.

### Payload Handling Updates:
* [`src/main/java/io/synadia/flink/v0/payload/Payload.java`](diffhunk://#diff-0d842ed285976547ca2854f59b486545afe5fa5750f2ec64e789e50c16d8224eL5-R39): Added `replyTo` field and made `headers` as  `Map<String, List<String>>` to ensure proper serialization. Implemented `Serializable` interface.

### Error Handling and Logging:
* [`src/main/java/io/synadia/flink/v0/emitter/NatsRecordEmitter.java`](diffhunk://#diff-18991d489bc9e0cf60bb1e76bab8b098343a348cc67923437a0e5d488d49df64R11-R19): Added logging and error handling for deserialization failures. [[1]](diffhunk://#diff-18991d489bc9e0cf60bb1e76bab8b098343a348cc67923437a0e5d488d49df64R11-R19) [[2]](diffhunk://#diff-18991d489bc9e0cf60bb1e76bab8b098343a348cc67923437a0e5d488d49df64R31-R38)

### Test and Utility Updates:
* [`src/test/java/io/synadia/io/synadia/flink/TestBase.java`](diffhunk://#diff-9347d7d0f3be8506841a5068f859275ea7756d7cc15de70803f39c2a06e1dc18R305-R343): Added `AckMessageFunction` to simulate message acknowledgment in tests.
* [`src/main/java/io/synadia/flink/v0/utils/ConnectionContext.java`](diffhunk://#diff-cbe27a94d2cae4feb0a4241230f63ecc736b27b602f6aafff21ece53c78dda64R10-R16): Moved `ACK_BODY_BYTES` to `ConnectionContext` for better accessibility.