### PR TITLE
Add Support for NATS Message Serialization/De-Serialization

### DIFF
--- a/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitSerializer.java
+++ b/src/main/java/io/synadia/flink/v0/source/split/NatsSubjectSplitSerializer.java
@@ -3,6 +3,9 @@
 
 package io.synadia.flink.v0.source.split;
 
+import io.nats.client.Message;
+import io.nats.client.impl.Headers;
+import io.nats.client.impl.NatsMessage;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
@@ -11,6 +14,9 @@ import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.DataOutputView;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Serializes and deserializes the {@link NatsSubjectSplit}. This class needs to handle
@@ -19,7 +25,7 @@ import java.io.IOException;
 @Internal
 public class NatsSubjectSplitSerializer implements SimpleVersionedSerializer<NatsSubjectSplit> {
 
-    public static final int CURRENT_VERSION = 1;
+    public static final int CURRENT_VERSION = 2;
 
     @Override
     public int getVersion() {
@@ -30,7 +36,7 @@ public class NatsSubjectSplitSerializer implements SimpleVersionedSerializer<Nat
     public byte[] serialize(NatsSubjectSplit split) throws IOException {
         final DataOutputSerializer out =
             new DataOutputSerializer(split.splitId().length());
-        serializeV1(out, split);
+        serializeV2(out, split);
         return out.getCopyOfBuffer();
     }
 
@@ -38,16 +44,159 @@ public class NatsSubjectSplitSerializer implements SimpleVersionedSerializer<Nat
         out.writeUTF(split.splitId());
     }
 
+    public static void serializeV2(DataOutputView out, NatsSubjectSplit split) throws IOException {
+        if (split.splitId() == null) {
+            throw new IOException("Split ID cannot be null");
+        }
+
+        out.writeUTF(split.splitId());
+        out.writeInt(split.getCurrentMessages().size());
+        for (Message message : split.getCurrentMessages()) {
+            serializeNatsMessage(out, message);
+        }
+    }
+
     @Override
     public NatsSubjectSplit deserialize(int version, byte[] serialized) throws IOException {
-        if (version != CURRENT_VERSION) {
-            throw new IOException("Unrecognized version: " + version);
-        }
         final DataInputDeserializer in = new DataInputDeserializer(serialized);
-        return deserializeV1(in);
+
+        // check version
+        // handle older versions
+        if (version == 1) {
+            return deserializeV1(in);
+        } else if (version == 2) {
+            return deserializeV2(in);
+        } else {
+            throw new IOException("Unrecognized version or corrupted state: " + version);
+        }
     }
 
     static NatsSubjectSplit deserializeV1(DataInputView in) throws IOException {
         return new NatsSubjectSplit(in.readUTF());
     }
+
+    static NatsSubjectSplit deserializeV2(DataInputView in) throws IOException {
+        String subject = in.readUTF();
+        List<Message> messages = new ArrayList<>();
+        int numOfMessages = in.readInt();
+        for (int i = 0; i < numOfMessages; i++) {
+            messages.add(deserializeNatsMessage(in));
+        }
+
+        return new NatsSubjectSplit(subject, messages);
+    }
+
+    // Deserialize individual NATS Message
+    private static Message deserializeNatsMessage(DataInputView in) throws IOException {
+        // Deserialize subject
+        String subject = in.readBoolean() ? in.readUTF() : null;
+
+        Headers headers = in.readBoolean()? new Headers() : null;
+        if (headers != null) {
+            deserializeHeaders(in, headers);
+        }
+
+        // Deserialize replyTo
+        String replyTo = in.readBoolean() ? in.readUTF() : null;
+
+        // Deserialize data
+        int dataLength = in.readInt();
+        byte[] data = null;
+        if (dataLength != -1) {
+            data = new byte[dataLength];
+            in.readFully(data);
+        }
+
+        NatsMessage.Builder builder = NatsMessage.builder();
+        builder.subject(subject);
+
+        if (data != null) {
+            builder.data(data);
+        }
+
+        if (replyTo != null) {
+            builder.replyTo(replyTo);
+        }
+
+        if (headers != null) {
+            builder.headers(headers);
+        }
+
+        return builder.build();
+    }
+
+    // Serialize individual NATS Message
+    private static void serializeNatsMessage(DataOutputView out, Message message) throws IOException {
+        // Serialize subject
+        if (message.getSubject() == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeUTF(message.getSubject());
+        }
+
+        // serialize headers
+        if (message.getHeaders() == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            serializeHeaders(out, message);
+        }
+
+        // Serialize replyTo
+        if (message.getReplyTo() == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeUTF(message.getReplyTo());
+        }
+
+        // Serialize data (payload)
+        if (message.getData() == null) {
+            out.writeInt(-1);
+        } else {
+            out.writeInt(message.getData().length);
+            out.write(message.getData());
+        }
+    }
+
+    private static void serializeHeaders(DataOutputView out, Message message) throws IOException {
+        Set<String> keys = message.getHeaders().keySet();
+        out.writeInt(keys.size());
+
+        // serialize headers
+        for (String key : keys) {
+            out.writeUTF(key);
+
+            // serialize header value
+            List<String> values = message.getHeaders().get(key);
+            out.writeInt(values.size());
+
+            for (String value : values) {
+                out.writeUTF(value);
+            }
+        }
+    }
+
+    private static void deserializeHeaders(DataInputView in, Headers headers) throws IOException {
+        // Deserialize headers
+        int numOfKeys = in.readInt();
+
+        for (int i = 0; i < numOfKeys; i++) {
+            String key = in.readUTF();
+            List<String> values = new ArrayList<>();
+
+            int numOfValues = in.readInt();
+            for (int j = 0; j < numOfValues; j++) {
+
+                String value = in.readUTF();
+                values.add(value);
+            }
+
+            // add back
+            headers.add(key, values);
+        }
+    }
 }
+
+


### PR DESCRIPTION
Add Support for NATS Message (Subject, Data, replyTo & Headers) Serialization/De-Serialization

**Overview:**

Currently, we only checkpoint the subject, but we should also preserve message information

### Changes in This PR:

1. Introduces a new version that includes the list of messages in each split while ensuring backward compatibility with version 1 during deserialization. 
2. Each message will now include: 
    - Subject
    - Headers
    - Body (Data)
    - Reply-To Information (for acknowledgment)
    
3. During deserialization, the messages will be reconstructed as Message objects along with the split.


This enhancement ensures that message metadata is retained and can be leveraged for downstream processing, particularly for acknowledgment

### Test cases: 
<img width="1081" alt="Screenshot 2025-01-29 at 4 09 57 PM" src="https://github.com/user-attachments/assets/ad88b328-79da-4bea-8797-4f7ca028e5e1" />


