### PR TITLE
Support ackWait

### DIFF
--- a/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
@@ -93,7 +93,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             JsonUtils.addField(sb, THRESHOLD_PERCENT, co.getThresholdPercent());
         }
 
-        if (!ackWait.isZero()) {
+        if (ackWait != null) {
             JsonUtils.addFieldAsNanos(sb, ACK_WAIT, ackWait);
         }
 
@@ -179,7 +179,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
         private ZonedDateTime startTime;
         private long maxMessagesToRead = -1;
         private AckBehavior ackBehavior = AckBehavior.NoAck;
-        private Duration ackWait = Duration.ZERO;
+        private Duration ackWait;
         private int batchSize = -1;
         private int thresholdPercent = -1;
 
@@ -287,11 +287,24 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
         /**
          * Sets the ack wait for the consumer.
          * Note: This is not applicable when ackBehavior is set to AckBehavior.NoAck
+         * @param millis the ack wait in milliseconds
+         * @return the builder
+         */
+        public Builder ackWait(long millis) {
+            this.ackWait = millis <= 0L ? null : Duration.ofMillis(millis);;
+            return this;
+        }
+
+        /**
+         * Sets the ack wait for the consumer.
+         * Note: This is not applicable when ackBehavior is set to AckBehavior.NoAck
          * @param ackWait the ack wait in Duration
          * @return the builder
          */
         public Builder ackWait(Duration ackWait) {
-            if (ackWait != null && !ackWait.isZero() && !ackWait.isNegative()) {
+            if (ackWait == null || ackWait.isZero() || ackWait.isNegative()) {
+                this.ackWait = null;
+            } else {
                 this.ackWait = ackWait;
             }
 
@@ -339,7 +352,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
                 throw new IllegalArgumentException("Stream name is required.");
             }
 
-            if (ackBehavior == AckBehavior.NoAck && !ackWait.isZero()) {
+            if (ackBehavior == AckBehavior.NoAck && ackWait != null) {
                 throw new IllegalArgumentException("ackWait cannot be set when ackBehavior is NoAck.");
             }
 

--- a/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
@@ -6,7 +6,6 @@ package io.synadia.flink.source;
 import io.nats.client.BaseConsumeOptions;
 import io.nats.client.ConsumeOptions;
 import io.nats.client.api.AckPolicy;
-import io.nats.client.api.ConsumerConfiguration;
 import io.nats.client.api.DeliverPolicy;
 import io.nats.client.support.*;
 import io.synadia.flink.utils.MiscUtils;
@@ -16,7 +15,6 @@ import org.apache.flink.api.connector.source.Boundedness;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 

--- a/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
@@ -120,7 +120,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             YamlUtils.addField(sb, indentLevel, THRESHOLD_PERCENT, co.getThresholdPercent());
         }
 
-        if (!ackWait.isZero()) {
+        if (ackWait != null) {
             YamlUtils.addFieldAsNanos(sb, indentLevel, ACK_WAIT, ackWait);
         }
 

--- a/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
@@ -154,7 +154,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             .batchSize(JsonValueUtils.readInteger(jv, BATCH_SIZE, -1))
             .thresholdPercent(JsonValueUtils.readInteger(jv, THRESHOLD_PERCENT, -1))
             .ackBehavior(AckBehavior.valueOf(JsonValueUtils.readString(jv, ACK_BEHAVIOR, AckBehavior.NoAck.toString())))
-            .ackWait(JsonValueUtils.readNanos(jv, ACK_WAIT, Duration.ZERO))
+            .ackWait(JsonValueUtils.readNanos(jv, ACK_WAIT))
             .build();
     }
 
@@ -168,7 +168,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             .batchSize(YamlUtils.readInteger(map, BATCH_SIZE, -1))
             .thresholdPercent(YamlUtils.readInteger(map, THRESHOLD_PERCENT, -1))
             .ackBehavior(AckBehavior.get(YamlUtils.readString(map, ACK_BEHAVIOR, AckPolicy.None.toString())))
-            .ackWait(YamlUtils.readNanos(map, ACK_WAIT, Duration.ZERO))
+            .ackWait(YamlUtils.readNanos(map, ACK_WAIT))
             .build();
     }
 

--- a/src/main/java/io/synadia/flink/source/reader/JetStreamSourceReader.java
+++ b/src/main/java/io/synadia/flink/source/reader/JetStreamSourceReader.java
@@ -168,7 +168,7 @@ public class JetStreamSourceReader<OutputT> implements SourceReader<OutputT, Jet
             .ackPolicy(split.subjectConfig.ackBehavior.ackPolicy)
             .filterSubject(split.subjectConfig.subject);
 
-        if (!split.subjectConfig.ackWait.isZero()) {
+        if (split.subjectConfig.ackWait != null) {
             b.ackWait(split.subjectConfig.ackWait);
         }
 

--- a/src/main/java/io/synadia/flink/source/reader/JetStreamSourceReader.java
+++ b/src/main/java/io/synadia/flink/source/reader/JetStreamSourceReader.java
@@ -168,6 +168,10 @@ public class JetStreamSourceReader<OutputT> implements SourceReader<OutputT, Jet
             .ackPolicy(split.subjectConfig.ackBehavior.ackPolicy)
             .filterSubject(split.subjectConfig.subject);
 
+        if (!split.subjectConfig.ackWait.isZero()) {
+            b.ackWait(split.subjectConfig.ackWait);
+        }
+
         long lastSeq = split.lastEmittedStreamSequence.get();
         if (lastSeq > 0) {
             b.deliverPolicy(DeliverPolicy.ByStartSequence).startSequence(lastSeq + 1);

--- a/src/main/java/io/synadia/flink/utils/Constants.java
+++ b/src/main/java/io/synadia/flink/utils/Constants.java
@@ -28,6 +28,7 @@ public interface Constants {
     String START_TIME = "start_time";
     String MAX_MESSAGES_TO_READ = "max_messages_to_read";
     String ACK_BEHAVIOR = "ack_behavior";
+    String ACK_WAIT = "ack_wait";
     String BATCH_SIZE = "batch_size";
     String THRESHOLD_PERCENT = "threshold_percent";
 

--- a/src/main/java/io/synadia/flink/utils/YamlUtils.java
+++ b/src/main/java/io/synadia/flink/utils/YamlUtils.java
@@ -185,9 +185,14 @@ public abstract class YamlUtils {
         return o instanceof Number ? ((Number)o).longValue() : dflt;
     }
 
+    public static Duration readNanos(Map<String, Object> map, String key) {
+        Long l = readLong(map, key);
+        return l == null? null : Duration.ofNanos(l);
+    }
+
     public static Duration readNanos(Map<String, Object> map, String key, Duration dflt) {
-        Object o = readObject(map, key);
-        return o instanceof Number ? Duration.ofNanos(((Number)o).longValue()) : dflt;
+        Long l = readLong(map, key);
+        return l == null ? dflt : Duration.ofNanos(l);
     }
 
     public static List<String> readStringList(Map<String, Object> map, String key) {

--- a/src/main/java/io/synadia/flink/utils/YamlUtils.java
+++ b/src/main/java/io/synadia/flink/utils/YamlUtils.java
@@ -4,8 +4,10 @@
 package io.synadia.flink.utils;
 
 import io.nats.client.support.DateTimeUtils;
+import io.nats.client.support.Encoding;
 import org.apache.flink.annotation.Internal;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
@@ -81,6 +83,13 @@ public abstract class YamlUtils {
         if (value != null && value > 0) {
             _addField(sb, indentLevel, key, value.toString());
         }
+    }
+
+    public static void addFieldAsNanos(StringBuilder sb, int indentLevel, String key, Duration value) {
+        if (value != null && !value.isZero() && !value.isNegative()) {
+            _addField(sb, indentLevel, key, String.valueOf(value.toNanos()));
+        }
+
     }
 
     public static void addField(StringBuilder sb, int indentLevel, String key, ZonedDateTime zonedDateTime) {
@@ -174,6 +183,11 @@ public abstract class YamlUtils {
     public static long readLong(Map<String, Object> map, String key, long dflt) {
         Object o = readObject(map, key);
         return o instanceof Number ? ((Number)o).longValue() : dflt;
+    }
+
+    public static Duration readNanos(Map<String, Object> map, String key, Duration dflt) {
+        Object o = readObject(map, key);
+        return o instanceof Number ? Duration.ofNanos(((Number)o).longValue()) : dflt;
     }
 
     public static List<String> readStringList(Map<String, Object> map, String key) {

--- a/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
+++ b/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
@@ -1,0 +1,399 @@
+// Copyright (c) 2023-2025 Synadia Communications Inc. All Rights Reserved.
+// See LICENSE and NOTICE file for details.
+
+package io.synadia.flink.source;
+
+import io.nats.client.api.DeliverPolicy;
+import io.nats.client.support.JsonParseException;
+import io.synadia.flink.TestBase;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JetStreamSubjectConfigurationTest extends TestBase {
+
+    private static final String TEST_STREAM = "test-stream";
+    private static final String TEST_SUBJECT = "test.subject";
+
+    @Test
+    public void testBasicConfiguration() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .build();
+
+        assertEquals(TEST_STREAM, config.streamName);
+        assertEquals(TEST_SUBJECT, config.subject);
+        assertEquals(-1, config.startSequence);
+        assertNull(config.startTime);
+        assertEquals(-1, config.maxMessagesToRead);
+        assertEquals(AckBehavior.NoAck, config.ackBehavior);
+        assertEquals(Duration.ZERO, config.ackWait);
+        assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, config.boundedness);
+        assertNull(config.deliverPolicy);
+    }
+
+    @Test
+    public void testAckWaitWithValidAckBehavior() {
+        Duration ackWait = Duration.ofSeconds(30);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AckAll)
+                .ackWait(ackWait.toMillis())
+                .build();
+
+        assertEquals(AckBehavior.AckAll, config.ackBehavior);
+        assertEquals(ackWait, config.ackWait);
+    }
+
+    @Test
+    public void testAckWaitWithAllButDoNotAck() {
+        Duration ackWait = Duration.ofMinutes(2);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AllButDoNotAck)
+                .ackWait(ackWait.toMillis())
+                .build();
+
+        assertEquals(AckBehavior.AllButDoNotAck, config.ackBehavior);
+        assertEquals(ackWait, config.ackWait);
+    }
+
+    @Test
+    public void testAckWaitWithExplicitButDoNotAck() {
+        Duration ackWait = Duration.ofSeconds(45);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.ExplicitButDoNotAck)
+                .ackWait(ackWait.toMillis())
+                .build();
+
+        assertEquals(AckBehavior.ExplicitButDoNotAck, config.ackBehavior);
+        assertEquals(ackWait, config.ackWait);
+    }
+
+    @Test
+    public void testAckWaitWithNoAckThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            JetStreamSubjectConfiguration.builder()
+                    .streamName(TEST_STREAM)
+                    .subject(TEST_SUBJECT)
+                    .ackBehavior(AckBehavior.NoAck)
+                    .ackWait(30000) // 30 seconds
+                    .build();
+        });
+    }
+
+    @Test
+    public void testAckWaitZeroValueAllowed() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.NoAck)
+                .ackWait(0)
+                .build();
+
+        assertEquals(Duration.ZERO, config.ackWait);
+        assertEquals(AckBehavior.NoAck, config.ackBehavior);
+    }
+
+    @Test
+    public void testAckWaitNegativeValueBecomesZero() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AckAll)
+                .ackWait(-1000)
+                .build();
+
+        assertEquals(Duration.ZERO, config.ackWait);
+    }
+
+    @Test
+    public void testJsonSerializationWithAckWait() {
+        Duration ackWait = Duration.ofSeconds(60);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AckAll)
+                .ackWait(ackWait.toMillis())
+                .build();
+
+        String json = config.toJson();
+        assertTrue(json.contains("\"ack_wait\":" + ackWait.toMillis()));
+        assertTrue(json.contains("\"ack_behavior\":\"AckAll\""));
+    }
+
+    @Test
+    public void testJsonSerializationWithoutAckWait() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.NoAck)
+                .build();
+
+        String json = config.toJson();
+        assertFalse(json.contains("ack_wait"));
+        assertFalse(json.contains("ack_behavior")); // NoAck is default, so not included
+    }
+
+    @Test
+    public void testYamlSerializationWithAckWait() {
+        Duration ackWait = Duration.ofMinutes(5);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.ExplicitButDoNotAck)
+                .ackWait(ackWait.toMillis())
+                .build();
+
+        String yaml = config.toYaml(0);
+        assertTrue(yaml.contains("ack_wait: " + ackWait.toMillis()));
+        assertTrue(yaml.contains("ack_behavior: ExplicitButDoNotAck"));
+    }
+
+    @Test
+    public void testJsonDeserializationWithAckWait() throws JsonParseException {
+        String json = "{"
+                + "\"stream_name\":\"" + TEST_STREAM + "\","
+                + "\"subject\":\"" + TEST_SUBJECT + "\","
+                + "\"ack_behavior\":\"AckAll\","
+                + "\"ack_wait\":45000"
+                + "}";
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.fromJson(json);
+
+        assertEquals(TEST_STREAM, config.streamName);
+        assertEquals(TEST_SUBJECT, config.subject);
+        assertEquals(AckBehavior.AckAll, config.ackBehavior);
+        assertEquals(Duration.ofSeconds(45), config.ackWait);
+    }
+
+    @Test
+    public void testMapDeserializationWithAckWait() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("stream_name", TEST_STREAM);
+        map.put("subject", TEST_SUBJECT);
+        map.put("ack_behavior", "AllButDoNotAck");
+        map.put("ack_wait", 120000L);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.fromMap(map);
+
+        assertEquals(TEST_STREAM, config.streamName);
+        assertEquals(TEST_SUBJECT, config.subject);
+        assertEquals(AckBehavior.AllButDoNotAck, config.ackBehavior);
+        assertEquals(Duration.ofMinutes(2), config.ackWait);
+    }
+
+    @Test
+    public void testCopyMethodPreservesAckWait() {
+        Duration originalAckWait = Duration.ofSeconds(30);
+
+        JetStreamSubjectConfiguration original = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject("original.subject")
+                .ackBehavior(AckBehavior.AckAll)
+                .ackWait(originalAckWait.toMillis())
+                .build();
+
+        JetStreamSubjectConfiguration copy = original.copy("new.subject");
+
+        assertEquals("new.subject", copy.subject);
+        assertEquals(TEST_STREAM, copy.streamName);
+        assertEquals(AckBehavior.AckAll, copy.ackBehavior);
+        assertEquals(originalAckWait, copy.ackWait);
+    }
+
+    @Test
+    public void testBuilderCopyMethodPreservesAckWait() {
+        Duration originalAckWait = Duration.ofMinutes(1);
+
+        JetStreamSubjectConfiguration original = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject("original.subject")
+                .ackBehavior(AckBehavior.ExplicitButDoNotAck)
+                .ackWait(originalAckWait.toMillis())
+                .maxMessagesToRead(100)
+                .build();
+
+        JetStreamSubjectConfiguration copy = JetStreamSubjectConfiguration.builder()
+                .copy(original)
+                .subject("copied.subject")
+                .build();
+
+        assertEquals("copied.subject", copy.subject);
+        assertEquals(TEST_STREAM, copy.streamName);
+        assertEquals(AckBehavior.ExplicitButDoNotAck, copy.ackBehavior);
+        assertEquals(originalAckWait, copy.ackWait);
+        assertEquals(100, copy.maxMessagesToRead);
+    }
+
+    @Test
+    public void testEqualsAndHashCodeWithAckWait() {
+        Duration ackWait = Duration.ofSeconds(30);
+
+        JetStreamSubjectConfiguration config1 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AckAll)
+                .ackWait(ackWait.toMillis())
+                .build();
+
+        JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AckAll)
+                .ackWait(ackWait.toMillis())
+                .build();
+
+        assertEquals(config1, config2);
+        assertEquals(config1.hashCode(), config2.hashCode());
+    }
+
+    @Test
+    public void testNotEqualsWithDifferentAckWait() {
+        JetStreamSubjectConfiguration config1 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AckAll)
+                .ackWait(30000)
+                .build();
+
+        JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AckAll)
+                .ackWait(60000)
+                .build();
+
+        assertNotEquals(config1, config2);
+    }
+
+    @Test
+    public void testCompleteConfigurationWithAckWait() {
+        ZonedDateTime startTime = ZonedDateTime.now().minusHours(1);
+        Duration ackWait = Duration.ofSeconds(90);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .startTime(startTime)
+                .maxMessagesToRead(1000)
+                .ackBehavior(AckBehavior.AllButDoNotAck)
+                .ackWait(ackWait.toMillis())
+                .batchSize(50)
+                .thresholdPercent(80)
+                .build();
+
+        assertEquals(TEST_STREAM, config.streamName);
+        assertEquals(TEST_SUBJECT, config.subject);
+        assertEquals(startTime, config.startTime);
+        assertEquals(1000, config.maxMessagesToRead);
+        assertEquals(AckBehavior.AllButDoNotAck, config.ackBehavior);
+        assertEquals(ackWait, config.ackWait);
+        assertEquals(Boundedness.BOUNDED, config.boundedness);
+        assertEquals(DeliverPolicy.ByStartTime, config.deliverPolicy);
+        assertEquals(50, config.serializableConsumeOptions.getConsumeOptions().getBatchSize());
+        assertEquals(80, config.serializableConsumeOptions.getConsumeOptions().getThresholdPercent());
+    }
+
+    @Test
+    public void testRequiredFieldsValidation() {
+        // Missing subject
+        assertThrows(IllegalArgumentException.class, () -> {
+            JetStreamSubjectConfiguration.builder()
+                    .streamName(TEST_STREAM)
+                    .build();
+        });
+
+        // Missing stream name
+        assertThrows(IllegalArgumentException.class, () -> {
+            JetStreamSubjectConfiguration.builder()
+                    .subject(TEST_SUBJECT)
+                    .build();
+        });
+    }
+
+    @Test
+    public void testStartSequenceAndStartTimeExclusive() {
+        ZonedDateTime startTime = ZonedDateTime.now();
+
+        // Setting start sequence after start time should throw
+        assertThrows(IllegalArgumentException.class, () -> {
+            JetStreamSubjectConfiguration.builder()
+                    .streamName(TEST_STREAM)
+                    .subject(TEST_SUBJECT)
+                    .startTime(startTime)
+                    .startSequence(100)
+                    .build();
+        });
+
+        // Setting start time after start sequence should throw
+        assertThrows(IllegalArgumentException.class, () -> {
+            JetStreamSubjectConfiguration.builder()
+                    .streamName(TEST_STREAM)
+                    .subject(TEST_SUBJECT)
+                    .startSequence(100)
+                    .startTime(startTime)
+                    .build();
+        });
+    }
+
+    @Test
+    public void testDeliverPolicyBasedOnStartConfiguration() {
+        // No start configuration
+        JetStreamSubjectConfiguration config1 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .build();
+        assertNull(config1.deliverPolicy);
+
+        // Start sequence
+        JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .startSequence(100)
+                .build();
+        assertEquals(DeliverPolicy.ByStartSequence, config2.deliverPolicy);
+
+        // Start time
+        JetStreamSubjectConfiguration config3 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .startTime(ZonedDateTime.now())
+                .build();
+        assertEquals(DeliverPolicy.ByStartTime, config3.deliverPolicy);
+    }
+
+    @Test
+    public void testBoundednessBasedOnMaxMessages() {
+        // Unbounded (default)
+        JetStreamSubjectConfiguration config1 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .build();
+        assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, config1.boundedness);
+
+        // Bounded
+        JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxMessagesToRead(500)
+                .build();
+        assertEquals(Boundedness.BOUNDED, config2.boundedness);
+    }
+}

--- a/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
+++ b/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
@@ -34,7 +34,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
         assertNull(config.startTime);
         assertEquals(-1, config.maxMessagesToRead);
         assertEquals(AckBehavior.NoAck, config.ackBehavior);
-        assertEquals(Duration.ZERO, config.ackWait);
+        assertNull(config.ackWait);
         assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, config.boundedness);
         assertNull(config.deliverPolicy);
     }
@@ -70,6 +70,21 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
     }
 
     @Test
+    public void testAckWaitMillisWithAllButDoNotAck() {
+        Duration ackWait = Duration.ofMinutes(2);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.AllButDoNotAck)
+                .ackWait(ackWait.toMillis())
+                .build();
+
+        assertEquals(AckBehavior.AllButDoNotAck, config.ackBehavior);
+        assertEquals(ackWait, config.ackWait);
+    }
+
+    @Test
     public void testAckWaitWithExplicitButDoNotAck() {
         Duration ackWait = Duration.ofSeconds(45);
 
@@ -78,6 +93,21 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.ExplicitButDoNotAck)
                 .ackWait(ackWait)
+                .build();
+
+        assertEquals(AckBehavior.ExplicitButDoNotAck, config.ackBehavior);
+        assertEquals(ackWait, config.ackWait);
+    }
+
+    @Test
+    public void testAckWaitMillisWithExplicitButDoNotAck() {
+        Duration ackWait = Duration.ofSeconds(45);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.ExplicitButDoNotAck)
+                .ackWait(ackWait.toMillis())
                 .build();
 
         assertEquals(AckBehavior.ExplicitButDoNotAck, config.ackBehavior);
@@ -97,6 +127,18 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
     }
 
     @Test
+    public void testAckWaitMillisWithNoAckThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            JetStreamSubjectConfiguration.builder()
+                    .streamName(TEST_STREAM)
+                    .subject(TEST_SUBJECT)
+                    .ackBehavior(AckBehavior.NoAck)
+                    .ackWait(Duration.ofSeconds(30).toMillis())
+                    .build();
+        });
+    }
+
+    @Test
     public void testAckWaitZeroValueAllowed() {
         JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
                 .streamName(TEST_STREAM)
@@ -105,20 +147,33 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .ackWait(Duration.ZERO)
                 .build();
 
-        assertEquals(Duration.ZERO, config.ackWait);
+        assertNull(config.ackWait);
         assertEquals(AckBehavior.NoAck, config.ackBehavior);
     }
 
     @Test
-    public void testAckWaitNegativeValueBecomesZero() {
+    public void testAckWaitMillisZeroValueAllowed() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .ackBehavior(AckBehavior.NoAck)
+                .ackWait(Duration.ZERO.toMillis())
+                .build();
+
+        assertNull(config.ackWait);
+        assertEquals(AckBehavior.NoAck, config.ackBehavior);
+    }
+
+    @Test
+    public void testAckWaitMillisNegativeValueBecomesZero() {
         JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(Duration.ofMillis(-1000))
+                .ackWait(Duration.ofMillis(-1000).toMillis())
                 .build();
 
-        assertEquals(Duration.ZERO, config.ackWait);
+        assertNull(config.ackWait);
     }
 
     @Test

--- a/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
+++ b/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
@@ -47,7 +47,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(ackWait.toMillis())
+                .ackWait(ackWait)
                 .build();
 
         assertEquals(AckBehavior.AckAll, config.ackBehavior);
@@ -62,7 +62,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AllButDoNotAck)
-                .ackWait(ackWait.toMillis())
+                .ackWait(ackWait)
                 .build();
 
         assertEquals(AckBehavior.AllButDoNotAck, config.ackBehavior);
@@ -77,7 +77,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.ExplicitButDoNotAck)
-                .ackWait(ackWait.toMillis())
+                .ackWait(ackWait)
                 .build();
 
         assertEquals(AckBehavior.ExplicitButDoNotAck, config.ackBehavior);
@@ -91,7 +91,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                     .streamName(TEST_STREAM)
                     .subject(TEST_SUBJECT)
                     .ackBehavior(AckBehavior.NoAck)
-                    .ackWait(30000) // 30 seconds
+                    .ackWait(Duration.ofSeconds(30))
                     .build();
         });
     }
@@ -102,7 +102,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.NoAck)
-                .ackWait(0)
+                .ackWait(Duration.ZERO)
                 .build();
 
         assertEquals(Duration.ZERO, config.ackWait);
@@ -115,7 +115,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(-1000)
+                .ackWait(Duration.ofMillis(-1000))
                 .build();
 
         assertEquals(Duration.ZERO, config.ackWait);
@@ -129,11 +129,12 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(ackWait.toMillis())
+                .ackWait(ackWait)
                 .build();
 
         String json = config.toJson();
-        assertTrue(json.contains("\"ack_wait\":" + ackWait.toMillis()));
+        System.out.println(json);
+        assertTrue(json.contains("\"ack_wait\":" + ackWait.toNanos()));
         assertTrue(json.contains("\"ack_behavior\":\"AckAll\""));
     }
 
@@ -158,11 +159,11 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.ExplicitButDoNotAck)
-                .ackWait(ackWait.toMillis())
+                .ackWait(ackWait)
                 .build();
 
         String yaml = config.toYaml(0);
-        assertTrue(yaml.contains("ack_wait: " + ackWait.toMillis()));
+        assertTrue(yaml.contains("ack_wait: " + ackWait.toNanos()));
         assertTrue(yaml.contains("ack_behavior: ExplicitButDoNotAck"));
     }
 
@@ -172,7 +173,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 + "\"stream_name\":\"" + TEST_STREAM + "\","
                 + "\"subject\":\"" + TEST_SUBJECT + "\","
                 + "\"ack_behavior\":\"AckAll\","
-                + "\"ack_wait\":45000"
+                + "\"ack_wait\":" + Duration.ofSeconds(45).toNanos()
                 + "}";
 
         JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.fromJson(json);
@@ -189,14 +190,14 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
         map.put("stream_name", TEST_STREAM);
         map.put("subject", TEST_SUBJECT);
         map.put("ack_behavior", "AllButDoNotAck");
-        map.put("ack_wait", 120000L);
+        map.put("ack_wait", Duration.ofSeconds(12).toNanos());
 
         JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.fromMap(map);
 
         assertEquals(TEST_STREAM, config.streamName);
         assertEquals(TEST_SUBJECT, config.subject);
         assertEquals(AckBehavior.AllButDoNotAck, config.ackBehavior);
-        assertEquals(Duration.ofMinutes(2), config.ackWait);
+        assertEquals(Duration.ofSeconds(12), config.ackWait);
     }
 
     @Test
@@ -207,7 +208,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject("original.subject")
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(originalAckWait.toMillis())
+                .ackWait(originalAckWait)
                 .build();
 
         JetStreamSubjectConfiguration copy = original.copy("new.subject");
@@ -226,7 +227,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject("original.subject")
                 .ackBehavior(AckBehavior.ExplicitButDoNotAck)
-                .ackWait(originalAckWait.toMillis())
+                .ackWait(originalAckWait)
                 .maxMessagesToRead(100)
                 .build();
 
@@ -250,14 +251,14 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(ackWait.toMillis())
+                .ackWait(ackWait)
                 .build();
 
         JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(ackWait.toMillis())
+                .ackWait(ackWait)
                 .build();
 
         assertEquals(config1, config2);
@@ -270,14 +271,14 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(30000)
+                .ackWait(Duration.ofSeconds(30))
                 .build();
 
         JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
                 .streamName(TEST_STREAM)
                 .subject(TEST_SUBJECT)
                 .ackBehavior(AckBehavior.AckAll)
-                .ackWait(60000)
+                .ackWait(Duration.ofSeconds(60))
                 .build();
 
         assertNotEquals(config1, config2);
@@ -294,7 +295,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
                 .startTime(startTime)
                 .maxMessagesToRead(1000)
                 .ackBehavior(AckBehavior.AllButDoNotAck)
-                .ackWait(ackWait.toMillis())
+                .ackWait(ackWait)
                 .batchSize(50)
                 .thresholdPercent(80)
                 .build();

--- a/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
+++ b/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
@@ -397,3 +397,5 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
         assertEquals(Boundedness.BOUNDED, config2.boundedness);
     }
 }
+
+


### PR DESCRIPTION
This pull request introduces support for configuring `ackWait` in the `JetStreamSubjectConfiguration` class. The `ackWait` parameter allows users to specify the acknowledgment wait time for message consumers, enhancing control over acknowledgment behavior. The changes include updates to serialization, deserialization, validation, and builder methods to accommodate this new parameter.