### PR TITLE
remove restrictions on inactive threshold

### DIFF
--- a/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
@@ -352,13 +352,6 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
                 this.inactiveThreshold = null;
             }
             else {
-                Duration minThreshold = Duration.ofMinutes(5);
-                Duration maxThreshold = Duration.ofHours(2);
-
-                if (inactiveThreshold.compareTo(minThreshold) < 0 || inactiveThreshold.compareTo(maxThreshold) > 0) {
-                    throw new IllegalArgumentException("Inactive Threshold must be between 5 and 120 minutes inclusive.");
-                }
-
                 this.inactiveThreshold = inactiveThreshold;
             }
             return this;


### PR DESCRIPTION
This pull request removes the validation logic for the `inactiveThreshold` parameter in the `JetStreamSubjectConfiguration.Builder` class. The method no longer enforces that the threshold must be between 5 and 120 minutes.

Validation logic removal:

* Removed the check that enforced `inactiveThreshold` to be between 5 and 120 minutes in the `inactiveThreshold(Duration inactiveThreshold)` method of `JetStreamSubjectConfiguration.java`.