### PR TITLE
Redo Queue Size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.nats:jnats:2.24.0'
+    implementation 'io.nats:jnats:2.25.2'
     implementation 'org.jspecify:jspecify:1.0.0'
 
     // these are here to override flink since the flink dependency version has vulnerabilities

--- a/src/main/java/io/synadia/flink/source/JetStreamSourceBuilder.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSourceBuilder.java
@@ -177,7 +177,7 @@ public class JetStreamSourceBuilder<OutputT> extends BuilderBase<OutputT, JetStr
         if (queueCapacity > Integer.MAX_VALUE) {
             throw new IllegalArgumentException(
                 "Computed source queue capacity " + queueCapacity
-                    + " exceeds Integer.MAX_VALUE; reduce the per-subject batchSize / thresholdPercent.");
+                    + " exceeds Integer.MAX_VALUE; reduce the per-subject batchSize.");
         }
 
         SourceConfig config = new SourceConfig(boundedness, (int) queueCapacity);

--- a/src/main/java/io/synadia/flink/source/JetStreamSourceBuilder.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSourceBuilder.java
@@ -3,7 +3,6 @@
 
 package io.synadia.flink.source;
 
-import io.nats.client.ConsumeOptions;
 import io.nats.client.support.JsonValue;
 import io.nats.client.support.JsonValueUtils;
 import io.synadia.flink.message.SourceConverter;
@@ -154,13 +153,15 @@ public class JetStreamSourceBuilder<OutputT> extends BuilderBase<OutputT, JetStr
 
         // Walk the subject configs once: verify boundedness is consistent and
         // accumulate the source reader's queue capacity. Per-subject
-        // contribution is batchSize (the new pull just delivered) +
-        // max(1, batchSize * thresholdPercent / 100) (the messages still
-        // buffered when the re-pull was triggered) — the peak simultaneous
-        // queue depth for that subject. Summed across subjects so each split
-        // has room for its in-flight pull plus its still-buffered tail.
-        // Accumulator is long so a pathological mix of subjects can't silently
-        // wrap an int; we range-check before narrowing.
+        // contribution is batchSize: the pull engine keeps at most batchSize
+        // messages outstanding from the server, so one full batch per subject
+        // is all the buffer needed to keep messages flowing. Summed across
+        // subjects since they share one reader queue, giving each split room
+        // for a full concurrent batch. (The queue is blocking, so this is a
+        // throughput buffer, not a correctness bound — a smaller queue just
+        // parks the pull dispatcher in put() more often.) Accumulator is long
+        // so a pathological mix of subjects can't silently wrap an int; we
+        // range-check before narrowing.
         Boundedness boundedness = null;
         long queueCapacity = 0L;
         for (JetStreamSubjectConfiguration msc : configById.values()) {
@@ -170,9 +171,7 @@ public class JetStreamSourceBuilder<OutputT> extends BuilderBase<OutputT, JetStr
             else if (boundedness != msc.boundedness) {
                 throw new IllegalArgumentException("All boundedness must be the same.");
             }
-            ConsumeOptions co = msc.serializableConsumeOptions.getConsumeOptions();
-            long batchSize = co.getBatchSize();
-            queueCapacity += batchSize + Math.max(1L, batchSize * co.getThresholdPercent() / 100);
+            queueCapacity += msc.serializableConsumeOptions.getConsumeOptions().getBatchSize();
         }
 
         if (queueCapacity > Integer.MAX_VALUE) {

--- a/src/test/java/io/synadia/flink/source/JetStreamSourceBuilderTest.java
+++ b/src/test/java/io/synadia/flink/source/JetStreamSourceBuilderTest.java
@@ -198,12 +198,10 @@ class JetStreamSourceBuilderTest extends TestBase {
     }
 
     @Test
-    void testQueueCapacity_sumsBatchPlusRePullPerSubject() throws Exception {
-        // Two subjects at jnats defaults (batchSize=500, threshold=25%):
-        // per-subject contribution is 500 + max(1, 500*25/100) = 500 + 125 = 625.
-        int defaultPer = BaseConsumeOptions.DEFAULT_MESSAGE_COUNT
-            + Math.max(1, BaseConsumeOptions.DEFAULT_MESSAGE_COUNT
-                * BaseConsumeOptions.DEFAULT_THRESHOLD_PERCENT / 100);
+    void testQueueCapacity_sumsBatchSizePerSubject() throws Exception {
+        // Two subjects at the jnats default batchSize (500): per-subject
+        // contribution is just batchSize, so the shared reader queue is 2 * 500.
+        int defaultPer = BaseConsumeOptions.DEFAULT_MESSAGE_COUNT;
 
         JetStreamSource<String> source = new JetStreamSourceBuilder<String>()
             .connectionPropertiesFile(TEST_CONNECTION_PROPERTIES_FILE)
@@ -216,29 +214,31 @@ class JetStreamSourceBuilderTest extends TestBase {
     }
 
     @Test
-    void testQueueCapacity_rePullFloorsAtOne() throws Exception {
-        // batchSize=1 with default threshold yields rePull = max(1, 0) = 1.
+    void testQueueCapacity_usesBatchSizeVerbatim() throws Exception {
+        // A subject's contribution is exactly its batchSize.
         JetStreamSource<String> source = new JetStreamSourceBuilder<String>()
             .connectionPropertiesFile(TEST_CONNECTION_PROPERTIES_FILE)
             .sourceConverter(new AsciiStringSourceConverter())
             .addSubjectConfigurations(JetStreamSubjectConfiguration.builder()
                 .streamName("S").subject("one").batchSize(1).build())
             .build();
-        assertEquals(2, source.config.sourceQueueCapacity);
+        assertEquals(1, source.config.sourceQueueCapacity);
     }
 
     @Test
     void testQueueCapacity_overflowsIntRangeThrows() {
-        // A single subject at Integer.MAX_VALUE batchSize contributes
-        // batchSize + max(1, batchSize * 25 / 100) ≈ 2.68 billion in long math,
-        // which exceeds Integer.MAX_VALUE — the range check after the
-        // accumulator should fire instead of silently wrapping to a negative.
+        // Two subjects each at Integer.MAX_VALUE batchSize sum to ~4.29 billion
+        // in long math, which exceeds Integer.MAX_VALUE — the range check after
+        // the accumulator should fire instead of silently wrapping to a negative.
         IllegalArgumentException iae = assertThrows(IllegalArgumentException.class,
             () -> new JetStreamSourceBuilder<String>()
                 .connectionPropertiesFile(TEST_CONNECTION_PROPERTIES_FILE)
                 .sourceConverter(new AsciiStringSourceConverter())
-                .addSubjectConfigurations(JetStreamSubjectConfiguration.builder()
-                    .streamName("S").subject("huge").batchSize(Integer.MAX_VALUE).build())
+                .addSubjectConfigurations(
+                    JetStreamSubjectConfiguration.builder()
+                        .streamName("S").subject("huge1").batchSize(Integer.MAX_VALUE).build(),
+                    JetStreamSubjectConfiguration.builder()
+                        .streamName("S").subject("huge2").batchSize(Integer.MAX_VALUE).build())
                 .build());
         assertTrue(iae.getMessage().contains("exceeds Integer.MAX_VALUE"), iae.getMessage());
     }


### PR DESCRIPTION
# Source Queue Capacity Sizing — Analysis

## The question

In `JetStreamSourceBuilder` the reader's queue capacity was computed per subject as:

```java
ConsumeOptions co = msc.serializableConsumeOptions.getConsumeOptions();
long batchSize = co.getBatchSize();
queueCapacity += batchSize + Math.max(1L, batchSize * co.getThresholdPercent() / 100);
```

The question: does it actually need that `+ threshold` headroom, or is it enough to size each
subject's contribution at just the batch size?

```java
queueCapacity += msc.serializableConsumeOptions.getConsumeOptions().getBatchSize();
```

## How the jnats pull engine actually behaves (jnats 2.25.2)

From `io.nats.client.impl.NatsMessageConsumer`:

```java
int rePullMessages = Math.max(1, bm * consumeOpts.getThresholdPercent() / 100);
thresholdMessages   = bm - rePullMessages;     // re-pull fires when pendingMessages <= this
```

And `pendingMessages` in `io.nats.client.impl.PullMessageManager` means **"requested from the
server but not yet received by the client"**:

- `pendingMessages += batchSize` at each pull (`startPullRequest`)
- `pendingMessages -= 1` as each message arrives (`trackIncoming`)
- in `pendingUpdated()`, when `pendingMessages <= thresholdMessages`, `repull()` runs and tops
  pending back up to `batchSize` (`rePullMessages = max(1, batchSize - pendingMessages)`)

So the **hard invariant** is: outstanding-from-server never exceeds `batchSize`. The
`Math.max(1L, batchSize * thresholdPercent / 100)` term that appeared in the builder is exactly
jnats's `rePullMessages` — the *refill gap*, i.e. how many short of a full batch the engine lets
pending drift before issuing the next pull.

## The key realization about the reader queue

The message handler puts **one message at a time** into a `FutureCompletingBlockingQueue`. At any
instant there are two **disjoint** sets of messages:

- **in the queue** — received, not yet drained by Flink's `pollNext`
- **pending** — requested, not yet received (≤ `batchSize`)

Because it is a **blocking** queue, `put()` blocks the jnats dispatcher thread when the queue is
full. Two consequences:

1. **Correctness does not depend on the capacity at all.** Any capacity ≥ 1 is correct. A
   too-small queue merely makes the dispatcher park in `put()` more often — that is ordinary
   backpressure. `pollNext` runs on Flink's task thread (separate from the jnats dispatcher), so it
   keeps draining and unblocks the dispatcher. No deadlock, no message loss.
2. The capacity is therefore purely a **throughput / latency buffer** to keep the dispatcher from
   stalling under normal flow — not a correctness bound.

## Is `batchSize` enough?

**Yes.** Sizing each subject's contribution at `batchSize` lets one full delivered batch sit
buffered while Flink works through it. Because the builder **sums** the contribution across all
subject configs (they share one reader queue), each subject still gets room for a full concurrent
batch.

The dropped `+ rePull` term was **deliberate headroom for the prefetch seam**: jnats issues the
next pull while `pending` is still `rePull` short of empty, so the next batch's messages can begin
arriving *before* the current buffered batch is fully drained. In a slow-drain moment at that seam,
up to `rePull` extra messages want a slot. With just `batchSize`, the dispatcher blocks `rePull`
messages sooner there.

This is a **tuning trade-off, not a correctness bug**:

- **`batchSize`** — cleaner, "one full batch per subject." Slightly more dispatcher parking at the
  batch seam under bursty/slow consumers. Functionally identical otherwise.
- **`batchSize + rePull`** — never blocks the dispatcher even at the prefetch overlap. Costs a bit
  more memory.

## Note on heartbeats

If Flink stalls draining long enough for the dispatcher to stay blocked in `put()` past the idle
heartbeat interval, status/heartbeat messages queued behind the user handler won't be processed and
a heartbeat alarm could fire. But that only happens when the pipeline has already stalled, and the
few extra slots from `+ rePull` don't materially change that — once drain stops long enough, the
queue fills regardless. So this does not argue for the larger size.

## Conclusion

The pull engine is *designed* to keep the buffer full up to `batchSize`, and the queue never
legitimately needs to hold more than one batch worth of *received* messages per subject to keep
flowing. `batchSize` is the honest minimum-that-keeps-flowing. Keep `+ threshold` only if you
specifically want to eliminate any dispatcher parking at the prefetch seam.

## Change applied

`src/main/java/io/synadia/flink/source/JetStreamSourceBuilder.java`:

- Per-subject contribution is now `getBatchSize()` only.
- Comment block updated to explain the batch-size-only rationale and that the blocking queue makes
  this a throughput buffer rather than a correctness bound.
- Removed the now-unused `import io.nats.client.ConsumeOptions;`.
- `gradle compileJava` passes.
