### PR TITLE
add maxAckPending support to JetStreamSubjectConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,8 @@ The source can be configured in code or from files on JSON or YAML format. It su
       "max_messages_to_read": 10000,
       "ack_behavior":  "NoAck",
       "batch_size": 100,
-      "threshold_percent": 25
+      "threshold_percent": 25,
+      "max_ack_pending": 5000
     },
     {
       "stream_name": "streamName",

--- a/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
@@ -103,6 +103,11 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
      */
     public final DeliverPolicy deliverPolicy;
 
+    /**
+     * The configured maxAckPending
+     */
+    public final long maxAckPending;
+
     private JetStreamSubjectConfiguration(Builder b, ConsumeOptions consumeOptions) {
         serializableConsumeOptions = new SerializableConsumeOptions(consumeOptions);
         subject = b.subject;
@@ -115,6 +120,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
         ackBehavior = b.ackBehavior;
         ackWait = b.ackWait;
         inactiveThreshold = b.inactiveThreshold;
+        maxAckPending = b.maxAckPending;
 
         boundedness = maxMessagesToRead > 0 ? Boundedness.BOUNDED : Boundedness.CONTINUOUS_UNBOUNDED;
         deliverPolicy = startSequence != -1
@@ -133,7 +139,8 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             ackBehavior,
             ackWait,
             inactiveThreshold,
-            serializableConsumeOptions.getConsumeOptions()
+            serializableConsumeOptions.getConsumeOptions(),
+            maxAckPending
         );
     }
 
@@ -151,6 +158,10 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
         JsonUtils.addEnumWhenNot(sb, ACK_BEHAVIOR, ackBehavior, AckBehavior.NoAck);
         JsonUtils.addFieldAsNanos(sb, ACK_WAIT, ackWait);
         JsonUtils.addFieldAsNanos(sb, INACTIVE_THRESHOLD, inactiveThreshold);
+
+        if (maxAckPending > 0) {
+            JsonUtils.addFieldWhenGtZero(sb, MAX_ACK_PENDING, maxAckPending);
+        }
 
         ConsumeOptions co = serializableConsumeOptions.getConsumeOptions();
         if (co.getBatchSize() != DEFAULT_MESSAGE_COUNT) {
@@ -180,6 +191,10 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
         YamlUtils.addEnumWhenNot(sb, indentLevel, ACK_BEHAVIOR, ackBehavior, AckBehavior.NoAck);
         YamlUtils.addFieldAsNanos(sb, indentLevel, ACK_WAIT, ackWait);
         YamlUtils.addFieldAsNanos(sb, indentLevel, INACTIVE_THRESHOLD, inactiveThreshold);
+
+        if (maxAckPending > 0) {
+            YamlUtils.addFieldGtZero(sb, indentLevel, MAX_ACK_PENDING, maxAckPending);
+        }
 
         ConsumeOptions co = serializableConsumeOptions.getConsumeOptions();
         if (co.getBatchSize() != DEFAULT_MESSAGE_COUNT) {
@@ -243,6 +258,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             .ackBehavior(AckBehavior.get(JsonValueUtils.readString(jv, ACK_BEHAVIOR)))
             .ackWait(JsonValueUtils.readNanos(jv, ACK_WAIT))
             .inactiveThreshold(JsonValueUtils.readNanos(jv, INACTIVE_THRESHOLD))
+            .maxAckPending(JsonValueUtils.readInteger(jv, MAX_ACK_PENDING, -1))
             .build();
     }
 
@@ -266,6 +282,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             .ackBehavior(AckBehavior.get(YamlUtils.readString(map, ACK_BEHAVIOR)))
             .ackWait(YamlUtils.readNanos(map, ACK_WAIT))
             .inactiveThreshold(YamlUtils.readNanos(map, INACTIVE_THRESHOLD))
+            .maxAckPending(YamlUtils.readInteger(map, MAX_ACK_PENDING, -1))
             .build();
     }
 
@@ -285,6 +302,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
         private int batchSize = -1;
         private int thresholdPercent = -1;
         private Duration inactiveThreshold;
+        private long maxAckPending = -1;
 
         /**
          * Copies all the configuration except the subject and durable name.
@@ -301,7 +319,8 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
                 .ackWait(config.ackWait)
                 .inactiveThreshold(config.inactiveThreshold)
                 .batchSize(config.serializableConsumeOptions.getConsumeOptions().getBatchSize())
-                .thresholdPercent(config.serializableConsumeOptions.getConsumeOptions().getThresholdPercent());
+                .thresholdPercent(config.serializableConsumeOptions.getConsumeOptions().getThresholdPercent())
+                .maxAckPending(config.maxAckPending);
         }
 
         /**
@@ -457,6 +476,19 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
                 this.ackWait = ackWait;
             }
 
+            return this;
+        }
+
+        /**
+         * Set the maximum number of unacknowledged messages the NATS server will allow for this consumer.
+         * This directly maps to the NATS JetStream consumer max_ack_pending configuration.
+         * Without this, the server default (1000) is used and messages will pile up when production is fast.
+         *
+         * @param maxAckPending the max ack pending value, less than 1 means server default
+         * @return the builder
+         */
+        public Builder maxAckPending(long maxAckPending) {
+            this.maxAckPending = maxAckPending < 1 ? -1 : maxAckPending;
             return this;
         }
 

--- a/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
+++ b/src/main/java/io/synadia/flink/source/JetStreamSubjectConfiguration.java
@@ -158,10 +158,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
         JsonUtils.addEnumWhenNot(sb, ACK_BEHAVIOR, ackBehavior, AckBehavior.NoAck);
         JsonUtils.addFieldAsNanos(sb, ACK_WAIT, ackWait);
         JsonUtils.addFieldAsNanos(sb, INACTIVE_THRESHOLD, inactiveThreshold);
-
-        if (maxAckPending > 0) {
-            JsonUtils.addFieldWhenGtZero(sb, MAX_ACK_PENDING, maxAckPending);
-        }
+        JsonUtils.addFieldWhenGtZero(sb, MAX_ACK_PENDING, maxAckPending);
 
         ConsumeOptions co = serializableConsumeOptions.getConsumeOptions();
         if (co.getBatchSize() != DEFAULT_MESSAGE_COUNT) {
@@ -191,10 +188,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
         YamlUtils.addEnumWhenNot(sb, indentLevel, ACK_BEHAVIOR, ackBehavior, AckBehavior.NoAck);
         YamlUtils.addFieldAsNanos(sb, indentLevel, ACK_WAIT, ackWait);
         YamlUtils.addFieldAsNanos(sb, indentLevel, INACTIVE_THRESHOLD, inactiveThreshold);
-
-        if (maxAckPending > 0) {
-            YamlUtils.addFieldGtZero(sb, indentLevel, MAX_ACK_PENDING, maxAckPending);
-        }
+        YamlUtils.addFieldGtZero(sb, indentLevel, MAX_ACK_PENDING, maxAckPending);
 
         ConsumeOptions co = serializableConsumeOptions.getConsumeOptions();
         if (co.getBatchSize() != DEFAULT_MESSAGE_COUNT) {
@@ -258,7 +252,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             .ackBehavior(AckBehavior.get(JsonValueUtils.readString(jv, ACK_BEHAVIOR)))
             .ackWait(JsonValueUtils.readNanos(jv, ACK_WAIT))
             .inactiveThreshold(JsonValueUtils.readNanos(jv, INACTIVE_THRESHOLD))
-            .maxAckPending(JsonValueUtils.readInteger(jv, MAX_ACK_PENDING, -1))
+            .maxAckPending(JsonValueUtils.readLong(jv, MAX_ACK_PENDING, -1))
             .build();
     }
 
@@ -282,7 +276,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
             .ackBehavior(AckBehavior.get(YamlUtils.readString(map, ACK_BEHAVIOR)))
             .ackWait(YamlUtils.readNanos(map, ACK_WAIT))
             .inactiveThreshold(YamlUtils.readNanos(map, INACTIVE_THRESHOLD))
-            .maxAckPending(YamlUtils.readInteger(map, MAX_ACK_PENDING, -1))
+            .maxAckPending(YamlUtils.readLong(map, MAX_ACK_PENDING, -1))
             .build();
     }
 
@@ -483,6 +477,7 @@ public class JetStreamSubjectConfiguration implements JsonSerializable, Serializ
          * Set the maximum number of unacknowledged messages the NATS server will allow for this consumer.
          * This directly maps to the NATS JetStream consumer max_ack_pending configuration.
          * Without this, the server default (1000) is used and messages will pile up when production is fast.
+         * Note: This is not applicable when ackBehavior is set to AckBehavior.NoAck or AckBehavior.NoAckUnordered
          *
          * @param maxAckPending the max ack pending value, less than 1 means server default
          * @return the builder

--- a/src/main/java/io/synadia/flink/source/reader/JetStreamSourceReader.java
+++ b/src/main/java/io/synadia/flink/source/reader/JetStreamSourceReader.java
@@ -220,6 +220,10 @@ public class JetStreamSourceReader<OutputT> implements SourceReader<OutputT, Jet
             .ackPolicy(split.subjectConfig.ackBehavior.ackPolicy)
             .filterSubject(split.subjectConfig.subject);
 
+        if (split.subjectConfig.maxAckPending > 0) {
+            b.maxAckPending(split.subjectConfig.maxAckPending);
+        }
+
         if (split.subjectConfig.ackWait != null) {
             b.ackWait(split.subjectConfig.ackWait);
         }

--- a/src/main/java/io/synadia/flink/utils/Constants.java
+++ b/src/main/java/io/synadia/flink/utils/Constants.java
@@ -116,6 +116,11 @@ public interface Constants {
      */
     String THRESHOLD_PERCENT = "threshold_percent";
 
+    /**
+     * JetStreamSubjectConfiguration JSON / YAML Configuration Field Name Constant
+     */
+    String MAX_ACK_PENDING = "max_ack_pending";
+
     // ===================================================================================
     // Sink and Source JSON / YAML Configuration Value Constants
     // ===================================================================================

--- a/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
+++ b/src/test/java/io/synadia/flink/source/JetStreamSubjectConfigurationTest.java
@@ -39,6 +39,7 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
         assertNull(config1.ackWait);
         assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, config1.boundedness);
         assertNull(config1.deliverPolicy);
+        assertEquals(-1, config1.maxAckPending);
 
         JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
             .streamName(TEST_STREAM)
@@ -1207,5 +1208,230 @@ public class JetStreamSubjectConfigurationTest extends TestBase {
 
         assertNull(config.durableName);
         assertEquals(AckBehavior.NoAck, config.ackBehavior);
+    }
+
+    // ========== maxAckPending Tests ==========
+
+    @Test
+    void testMaxAckPendingBuilderSetsAndNormalizes() {
+        // Default value is -1
+        JetStreamSubjectConfiguration configDefault = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .build();
+        assertEquals(-1, configDefault.maxAckPending);
+
+        // Value < 1 normalizes to -1
+        JetStreamSubjectConfiguration configZero = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(0)
+                .build();
+        assertEquals(-1, configZero.maxAckPending);
+
+        JetStreamSubjectConfiguration configNegative = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(-5)
+                .build();
+        assertEquals(-1, configNegative.maxAckPending);
+
+        // Valid value
+        JetStreamSubjectConfiguration configValid = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(500)
+                .build();
+        assertEquals(500, configValid.maxAckPending);
+    }
+
+    @Test
+    void testJsonSerializationWithMaxAckPending() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(200)
+                .build();
+
+        String json = config.toJson();
+        assertTrue(json.contains("\"max_ack_pending\":200"));
+    }
+
+    @Test
+    void testJsonSerializationWithoutMaxAckPending() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .build();
+
+        String json = config.toJson();
+        assertFalse(json.contains("max_ack_pending"));
+    }
+
+    @Test
+    void testYamlSerializationWithMaxAckPending() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(300)
+                .build();
+
+        String yaml = config.toYaml(0);
+        assertTrue(yaml.contains("max_ack_pending: 300"));
+    }
+
+    @Test
+    void testYamlSerializationWithoutMaxAckPending() {
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .build();
+
+        String yaml = config.toYaml(0);
+        assertFalse(yaml.contains("max_ack_pending"));
+    }
+
+    @Test
+    void testJsonDeserializationWithMaxAckPending() throws JsonParseException {
+        String json = "{"
+                + "\"stream_name\":\"" + TEST_STREAM + "\","
+                + "\"subject\":\"" + TEST_SUBJECT + "\","
+                + "\"max_ack_pending\":150"
+                + "}";
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.fromJson(json);
+
+        assertEquals(TEST_STREAM, config.streamName);
+        assertEquals(TEST_SUBJECT, config.subject);
+        assertEquals(150, config.maxAckPending);
+    }
+
+    @Test
+    void testJsonDeserializationWithoutMaxAckPending() throws JsonParseException {
+        String json = "{"
+                + "\"stream_name\":\"" + TEST_STREAM + "\","
+                + "\"subject\":\"" + TEST_SUBJECT + "\""
+                + "}";
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.fromJson(json);
+
+        assertEquals(-1, config.maxAckPending);
+    }
+
+    @Test
+    void testMapDeserializationWithMaxAckPending() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("stream_name", TEST_STREAM);
+        map.put("subject", TEST_SUBJECT);
+        map.put("max_ack_pending", 250L);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.fromMap(map);
+
+        assertEquals(TEST_STREAM, config.streamName);
+        assertEquals(TEST_SUBJECT, config.subject);
+        assertEquals(250, config.maxAckPending);
+    }
+
+    @Test
+    void testMapDeserializationWithoutMaxAckPending() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("stream_name", TEST_STREAM);
+        map.put("subject", TEST_SUBJECT);
+
+        JetStreamSubjectConfiguration config = JetStreamSubjectConfiguration.fromMap(map);
+
+        assertEquals(-1, config.maxAckPending);
+    }
+
+    @Test
+    void testCopyMethodPreservesMaxAckPending() {
+        JetStreamSubjectConfiguration original = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject("original.subject")
+                .ackBehavior(AckBehavior.AckAll)
+                .maxAckPending(400)
+                .build();
+
+        JetStreamSubjectConfiguration copy = original.copy("new.subject");
+
+        assertEquals("new.subject", copy.subject);
+        assertEquals(TEST_STREAM, copy.streamName);
+        assertEquals(AckBehavior.AckAll, copy.ackBehavior);
+        assertEquals(400, copy.maxAckPending);
+    }
+
+    @Test
+    void testBuilderCopyMethodPreservesMaxAckPending() {
+        JetStreamSubjectConfiguration original = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject("original.subject")
+                .ackBehavior(AckBehavior.AllButDoNotAck)
+                .maxAckPending(600)
+                .maxMessagesToRead(100)
+                .build();
+
+        JetStreamSubjectConfiguration copy = JetStreamSubjectConfiguration.builder()
+                .copy(original)
+                .subject("copied.subject")
+                .build();
+
+        assertEquals("copied.subject", copy.subject);
+        assertEquals(TEST_STREAM, copy.streamName);
+        assertEquals(AckBehavior.AllButDoNotAck, copy.ackBehavior);
+        assertEquals(600, copy.maxAckPending);
+        assertEquals(100, copy.maxMessagesToRead);
+    }
+
+    @Test
+    void testMaxAckPendingIsIncludedInChecksum() {
+        JetStreamSubjectConfiguration config1 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(100)
+                .build();
+
+        JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(200)
+                .build();
+
+        // Different maxAckPending values should result in different IDs (checksums)
+        assertNotEquals(config1.id, config2.id);
+    }
+
+    @Test
+    void testEqualsAndHashCodeWithMaxAckPending() {
+        JetStreamSubjectConfiguration config1 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(500)
+                .build();
+
+        JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(500)
+                .build();
+
+        assertEquals(config1, config2);
+        assertEquals(config1.hashCode(), config2.hashCode());
+    }
+
+    @Test
+    void testNotEqualsWithDifferentMaxAckPending() {
+        JetStreamSubjectConfiguration config1 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(100)
+                .build();
+
+        JetStreamSubjectConfiguration config2 = JetStreamSubjectConfiguration.builder()
+                .streamName(TEST_STREAM)
+                .subject(TEST_SUBJECT)
+                .maxAckPending(200)
+                .build();
+
+        assertNotEquals(config1, config2);
     }
 }


### PR DESCRIPTION
**What**
Expose the NATS JetStream consumer max_ack_pending setting through JetStreamSubjectConfiguration.Builder.maxAckPending(long).

**Why**
When the production rate is high and acks only happen at checkpoint boundaries (e.g. every 5 seconds with AckAll), unacknowledged messages quickly hit the 1000 limit and NATS stops delivering — causing the consumer to stall even though the pipeline could process more.

**Changes**
Add maxAckPending field to JetStreamSubjectConfiguration
Add maxAckPending(long) builder method
Support JSON/YAML serialization and deserialization (max_ack_pending)
Apply it in JetStreamSourceReader.createConsumer() via ConsumerConfiguration.Builder.maxAckPending()
Add MAX_ACK_PENDING constant to Constants

**Usage**
``` Java
JetStreamSubjectConfiguration.builder()
    .streamName("streamName")
    .durableName("durableName")
    .ackBehavior(AckAll)
    .subject("subject.>")
    .maxAckPending(5000)
    .build()
```
Or via JSON/YAML:
``` JSON
{
  "stream_name": "stream_name",
  "subject": "subject.>",
  "ack_behavior": "AckAll",
  "max_ack_pending": 5000
}
```

_A value less than 1 means "not set" (server default applies), so existing code is unaffected._